### PR TITLE
Completely remove read_gsd_shape_data parameter

### DIFF
--- a/glotzformats/gsdhoomdfilereader.py
+++ b/glotzformats/gsdhoomdfilereader.py
@@ -234,7 +234,7 @@ class GSDHOOMDFileReader(object):
                 xml_frame = xml_reader.read(xmlfile)[0]
                 traj = gsd_reader.read(gsdfile, xml_frame)
 
-    :param bool read_gsd_shape_data: This keyword is no longer in use. By default,
+    About the read_gsd_shape_data parameter: This parameter was removed. By default,
                 shape information is read from a passed frame object, if one
                 provided. Otherwise, shape information is read from the gsd file.
 


### PR DESCRIPTION
Completely resolves issue #40. After PR #55, it was decided to completely remove the `read_gsd_shape_data` flag.