### PR TITLE
Fixed logic in test_shapes.

### DIFF
--- a/glotzformats/getarfilereader.py
+++ b/glotzformats/getarfilereader.py
@@ -121,7 +121,7 @@ class GetarFrame(Frame):
                              self._records['dimensions'], self._frame)[0]
             # Fallback to detection based on z coordinates
             else:
-                zs = raw_frame.positions[:,2]
+                zs = raw_frame.positions[:, 2]
                 dimensions = 2 if np.allclose(zs, 0.0, atol=1e-7) else 3
 
             box = self._trajectory.getRecord(self._records['box'], self._frame)

--- a/glotzformats/posfilereader.py
+++ b/glotzformats/posfilereader.py
@@ -290,7 +290,7 @@ class PosFileFrame(Frame):
         else:
             pos = np.asarray(raw_frame.positions)
         # If all the z coordinates are close to zero, set box dimension to 2
-        if np.allclose(pos[:,2], 0.0, atol=1e-7):
+        if np.allclose(pos[:, 2], 0.0, atol=1e-7):
             raw_frame.box_dimensions = 2
 
         # If no valid orientations have been added, the array should be empty

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -31,10 +31,11 @@ def annotate_shape_test(test_class, shape_classes):
     for s in shape_classes:
         # skipping ellipsoid test until HOOMD provides a
         # get_type_shapes method for ellipsoids
-        if test_class == 'GetarShapeTest' and s != 'ellipsoid_3d':
-            s = ShapeTestData(s)
-            setattr(s, '__name__', '{}_{}'.format(test_class, s['name']))
-            yield s
+        if test_class == 'GetarFileReader' and s['name'] == 'ellipsoid_3d':
+            continue
+        s = ShapeTestData(s)
+        setattr(s, '__name__', '{}_{}'.format(test_class, s['name']))
+        yield s
 
 
 @ddt


### PR DESCRIPTION
The logic for skipping ellipsoids with GTAR files was actually causing all the shape tests to be skipped.