### PR TITLE
Parse Polygons in 2D POS files

### DIFF
--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -130,8 +130,7 @@ class POSShapeTest(ShapeTest):
 
     @data(*annotate_shape_test('PosFileReader', get_shape_classes()))
     def test_shapes(self, shape_class):
-        # Ignore 2D shapes because POS files assume everything is 3D
-        if shape_class['dimensions'] == 3:
+        if shape_class['dimensions'] == 3 or len(shape_class['params'].get('vertices', [])) >= 3:
             self.check_shape_class(shape_class)
 
 

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -29,10 +29,6 @@ class ShapeTestData(dict):
 
 def annotate_shape_test(test_class, shape_classes):
     for s in shape_classes:
-        # skipping ellipsoid test until HOOMD provides a
-        # get_type_shapes method for ellipsoids
-        if test_class == 'GetarFileReader' and s['name'] == 'ellipsoid_3d':
-            continue
         s = ShapeTestData(s)
         setattr(s, '__name__', '{}_{}'.format(test_class, s['name']))
         yield s
@@ -120,7 +116,10 @@ class GetarShapeTest(ShapeTest):
 
     @data(*annotate_shape_test('GetarFileReader', get_shape_classes()))
     def test_shapes(self, shape_class):
-        self.check_shape_class(shape_class)
+        # skipping ellipsoid test until HOOMD provides a
+        # get_type_shapes method for ellipsoids
+        if shape_class['name'] != 'ellipsoid_3d':
+            self.check_shape_class(shape_class)
 
 
 @ddt

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -130,7 +130,7 @@ class POSShapeTest(ShapeTest):
 
     @data(*annotate_shape_test('PosFileReader', get_shape_classes()))
     def test_shapes(self, shape_class):
-        if shape_class['dimensions'] == 3 or len(shape_class['params'].get('vertices', [])) >= 3:
+        if shape_class['dimensions'] == 3 or shape_class['cls'] == 'convex_polygon':
             self.check_shape_class(shape_class)
 
 


### PR DESCRIPTION
I was looking into the shape tests and noticed a lack of support for 2D shapes in POS files. In `tests/files/shapes/convex_polygon.pos`, it shows the shape definition is:
```
def A "poly3d 4 -0.5 -0.5 0 0.5 -0.5 0 0.5 0.5 0 -0.5 0.5 0  005984FF"
```

In this case, we have a reasonable way to resolve that this is actually a polygon instead of a polyhedron: the vertices are coplanar in the x-y plane, with z=0 for all vertices. No polyhedron can be confined in a plane like this, so it is best to parse this as a polygon.

However, in my understanding, this logic does NOT apply to spheropolygons. That is, a set of coplanar vertices becomes a 3D shape if a rounding radius is applied in 3D, so there is no way to know the intended dimensionality from the POS output alone (since POS boxes and vertex lengths always assume 3D). For now, I have only added 2D shape parsing for the non-rounded (normal polygon) case.

P.S. I considered an alliterative title, "PR: Parse Planar POS Polygons." :)