### PR TITLE
Added bumpversion configuration file.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 0.4.2
+commit = True
+tag = True
+message = Bump up to version {new_version}.
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:glotzformats/__init__.py]
+
+[bumpversion:file:doc/conf.py]
+


### PR DESCRIPTION
This PR adds support for [bumpversion](https://github.com/peritus/bumpversion).

It's a helpful utility. When you're making a release, just update all the other files (like the change log). Then the last step of the release process is `bumpversion patch` (or minor, or major). This does a find/replace for all your CURRENT version strings and replaces them with a NEW version string, and creates a commit with a version tag. When you run `git push`, this commit will be pushed (by default, without the tag). Then run `git push --tags` to add the tagged release. These tags show up when you run `git tag`. You can also check out tags with `git checkout v0.4.1`.