### PR TITLE
Raise attribute error when shapedef attribute is None

### DIFF
--- a/glotzformats/dcdfilereader.py
+++ b/glotzformats/dcdfilereader.py
@@ -176,10 +176,7 @@ class DCDFrame(Frame):
             raw_frame.data = copy.deepcopy(self.t_frame.data)
             raw_frame.data_keys = copy.deepcopy(self.t_frame.data_keys)
             raw_frame.box_dimensions = self.t_frame.box.dimensions
-            try:
-                raw_frame.shapedef = copy.deepcopy(self.t_frame.shapedef)
-            except AttributeError:
-                pass
+            raw_frame.shapdef = copy.deepcopy(getattr(self.t_frame, 'shapedef', None))
         if not self._loaded():
             self._load()
         assert self._loaded()

--- a/glotzformats/dcdfilereader.py
+++ b/glotzformats/dcdfilereader.py
@@ -176,7 +176,10 @@ class DCDFrame(Frame):
             raw_frame.data = copy.deepcopy(self.t_frame.data)
             raw_frame.data_keys = copy.deepcopy(self.t_frame.data_keys)
             raw_frame.box_dimensions = self.t_frame.box.dimensions
-            raw_frame.shapdef = copy.deepcopy(getattr(self.t_frame, 'shapedef', None))
+            try:
+                raw_frame.shapedef = copy.deepcopy(self.t_frame.shapedef)
+            except AttributeError:
+                pass
         if not self._loaded():
             self._load()
         assert self._loaded()

--- a/glotzformats/dcdfilereader.py
+++ b/glotzformats/dcdfilereader.py
@@ -175,8 +175,11 @@ class DCDFrame(Frame):
         if self.t_frame is not None:
             raw_frame.data = copy.deepcopy(self.t_frame.data)
             raw_frame.data_keys = copy.deepcopy(self.t_frame.data_keys)
-            raw_frame.shapedef = copy.deepcopy(self.t_frame.shapedef)
             raw_frame.box_dimensions = self.t_frame.box.dimensions
+            try:
+                raw_frame.shapedef = copy.deepcopy(self.t_frame.shapedef)
+            except AttributeError:
+                pass
         if not self._loaded():
             self._load()
         assert self._loaded()

--- a/glotzformats/getarfilereader.py
+++ b/glotzformats/getarfilereader.py
@@ -10,6 +10,7 @@ Authors: Matthew Spellings, Carl Simon Adorf
 
 import json
 import logging
+import collections
 
 import numpy as np
 import gtar
@@ -88,6 +89,7 @@ class GetarFrame(Frame):
 
     def read(self):
         raw_frame = _RawFrameData()
+        raw_frame.shapedef = collections.OrderedDict()
         gf_prop_map = {
             'position': 'positions',
             'orientation': 'orientations',

--- a/glotzformats/getarfilewriter.py
+++ b/glotzformats/getarfilewriter.py
@@ -92,8 +92,6 @@ class GetarFileWriter(object):
             try:
                 shape_contents.append(frame.shapedef[typename].shape_dict)
             except AttributeError:
-                logger.warn('Shape type {} is unsupported for getar writing.'.format(
-                    frame.shapedef[typename].__class__))
                 shape_contents.append(None)
             except KeyError:
                 logger.info('Type name \'{}\' has no stored shape information.'.format(

--- a/glotzformats/gsdhoomdfilereader.py
+++ b/glotzformats/gsdhoomdfilereader.py
@@ -64,7 +64,6 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
         else:
             return default
 
-    # shapedefs = dict()
     shapedefs = collections.OrderedDict()
     types = frame.particles.types
 
@@ -156,9 +155,8 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
             shapedefs[typename] = PolygonShape(
                 vertices=typeverts, color=None)
         return shapedefs
-
+    # If no shapes were detected, return None
     else:
-        # If no shapes were detected, return the empty shapedefs dict.
         return None
 
 
@@ -195,7 +193,6 @@ class GSDHoomdFrame(Frame):
 
     def read(self):
         raw_frame = _RawFrameData()
-        # raw_frame.shapedef = collections.OrderedDict()
         frame = self.traj.read_frame(self.frame_index)
         # If frame is provided, read shape data from it
         if self.t_frame is not None:
@@ -209,8 +206,6 @@ class GSDHoomdFrame(Frame):
         else:
             # Fallback to gsd shape data if no frame is provided
             raw_frame.shapedef = _parse_shape_definitions(frame, self.gsdfile, self.frame_index)
-            # raw_frame.shapedef.update(
-            #     _parse_shape_definitions(frame, self.gsdfile, self.frame_index))
         raw_frame.box = _box_matrix(frame.configuration.box)
         raw_frame.box_dimensions = int(frame.configuration.dimensions)
         raw_frame.types = [frame.particles.types[t] for t in frame.particles.typeid]

--- a/glotzformats/gsdhoomdfilereader.py
+++ b/glotzformats/gsdhoomdfilereader.py
@@ -64,7 +64,8 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
         else:
             return default
 
-    shapedefs = dict()
+    # shapedefs = dict()
+    shapedefs = collections.OrderedDict()
     types = frame.particles.types
 
     # Spheres
@@ -81,7 +82,7 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
         return shapedefs
 
     # Convex Polyhedra
-    if get_chunk(frame_index, 'state/hpmc/convex_polyhedron/N') is not None:
+    elif get_chunk(frame_index, 'state/hpmc/convex_polyhedron/N') is not None:
         N = get_chunk(frame_index, 'state/hpmc/convex_polyhedron/N')
         N_start = [sum(N[:i]) for i in range(len(N))]
         N_end = [sum(N[:i+1]) for i in range(len(N))]
@@ -93,7 +94,7 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
         return shapedefs
 
     # Convex Spheropolyhedra
-    if get_chunk(frame_index,
+    elif get_chunk(frame_index,
                  'state/hpmc/convex_spheropolyhedron/N') is not None:
         N = get_chunk(frame_index, 'state/hpmc/convex_spheropolyhedron/N')
         N_start = [sum(N[:i]) for i in range(len(N))]
@@ -109,16 +110,17 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
         return shapedefs
 
     # Ellipsoid
-    if get_chunk(frame_index, 'state/hpmc/ellipsoid/a') is not None:
+    elif get_chunk(frame_index, 'state/hpmc/ellipsoid/a') is not None:
         a_all = get_chunk(frame_index, 'state/hpmc/ellipsoid/a')
         b_all = get_chunk(frame_index, 'state/hpmc/ellipsoid/b')
         c_all = get_chunk(frame_index, 'state/hpmc/ellipsoid/c')
         for typename, a, b, c in zip(types, a_all, b_all, c_all):
             shapedefs[typename] = EllipsoidShape(
                 a=a, b=b, c=c, color=None)
+        return shapedefs
 
     # Convex Polygons
-    if get_chunk(frame_index, 'state/hpmc/convex_polygon/N') is not None:
+    elif get_chunk(frame_index, 'state/hpmc/convex_polygon/N') is not None:
         N = get_chunk(frame_index, 'state/hpmc/convex_polygon/N')
         N_start = [sum(N[:i]) for i in range(len(N))]
         N_end = [sum(N[:i+1]) for i in range(len(N))]
@@ -130,7 +132,7 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
         return shapedefs
 
     # Convex Spheropolygons
-    if get_chunk(frame_index, 'state/hpmc/convex_spheropolygon/N') is not None:
+    elif get_chunk(frame_index, 'state/hpmc/convex_spheropolygon/N') is not None:
         N = get_chunk(frame_index, 'state/hpmc/convex_spheropolygon/N')
         N_start = [sum(N[:i]) for i in range(len(N))]
         N_end = [sum(N[:i+1]) for i in range(len(N))]
@@ -144,7 +146,7 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
         return shapedefs
 
     # Simple Polygons
-    if get_chunk(frame_index, 'state/hpmc/simple_polygon/N') is not None:
+    elif get_chunk(frame_index, 'state/hpmc/simple_polygon/N') is not None:
         N = get_chunk(frame_index, 'state/hpmc/simple_polygon/N')
         N_start = [sum(N[:i]) for i in range(len(N))]
         N_end = [sum(N[:i+1]) for i in range(len(N))]
@@ -155,8 +157,9 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
                 vertices=typeverts, color=None)
         return shapedefs
 
-    # If no shapes were detected, return the empty shapedefs dict.
-    return shapedefs
+    else:
+        # If no shapes were detected, return the empty shapedefs dict.
+        return None
 
 
 class GSDHoomdFrame(Frame):
@@ -192,7 +195,7 @@ class GSDHoomdFrame(Frame):
 
     def read(self):
         raw_frame = _RawFrameData()
-        raw_frame.shapedef = collections.OrderedDict()
+        # raw_frame.shapedef = collections.OrderedDict()
         frame = self.traj.read_frame(self.frame_index)
         # If frame is provided, read shape data from it
         if self.t_frame is not None:
@@ -205,8 +208,9 @@ class GSDHoomdFrame(Frame):
                 pass
         else:
             # Fallback to gsd shape data if no frame is provided
-            raw_frame.shapedef.update(
-                _parse_shape_definitions(frame, self.gsdfile, self.frame_index))
+            raw_frame.shapedef = _parse_shape_definitions(frame, self.gsdfile, self.frame_index)
+            # raw_frame.shapedef.update(
+            #     _parse_shape_definitions(frame, self.gsdfile, self.frame_index))
         raw_frame.box = _box_matrix(frame.configuration.box)
         raw_frame.box_dimensions = int(frame.configuration.dimensions)
         raw_frame.types = [frame.particles.types[t] for t in frame.particles.typeid]

--- a/glotzformats/gsdhoomdfilereader.py
+++ b/glotzformats/gsdhoomdfilereader.py
@@ -26,6 +26,7 @@ The example is given for a hoomd-blue xml frame:
 import logging
 import warnings
 import copy
+import collections
 
 import numpy as np
 
@@ -191,6 +192,7 @@ class GSDHoomdFrame(Frame):
 
     def read(self):
         raw_frame = _RawFrameData()
+        raw_frame.shapedef = collections.OrderedDict()
         frame = self.traj.read_frame(self.frame_index)
         # If frame is provided, read shape data from it
         if self.t_frame is not None:

--- a/glotzformats/gsdhoomdfilereader.py
+++ b/glotzformats/gsdhoomdfilereader.py
@@ -93,8 +93,7 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
         return shapedefs
 
     # Convex Spheropolyhedra
-    elif get_chunk(frame_index,
-                 'state/hpmc/convex_spheropolyhedron/N') is not None:
+    elif get_chunk(frame_index, 'state/hpmc/convex_spheropolyhedron/N') is not None:
         N = get_chunk(frame_index, 'state/hpmc/convex_spheropolyhedron/N')
         N_start = [sum(N[:i]) for i in range(len(N))]
         N_end = [sum(N[:i+1]) for i in range(len(N))]

--- a/glotzformats/gsdhoomdfilereader.py
+++ b/glotzformats/gsdhoomdfilereader.py
@@ -198,8 +198,11 @@ class GSDHoomdFrame(Frame):
         if self.t_frame is not None:
             raw_frame.data = copy.deepcopy(self.t_frame.data)
             raw_frame.data_keys = copy.deepcopy(self.t_frame.data_keys)
-            raw_frame.shapedef = copy.deepcopy(self.t_frame.shapedef)
             raw_frame.box_dimensions = self.t_frame.box.dimensions
+            try:
+                raw_frame.shapedef = copy.deepcopy(self.t_frame.shapedef)
+            except AttributeError:
+                pass
         else:
             # Fallback to gsd shape data if no frame is provided
             raw_frame.shapedef.update(

--- a/glotzformats/posfilereader.py
+++ b/glotzformats/posfilereader.py
@@ -222,6 +222,7 @@ class PosFileFrame(Frame):
                     "Failed to read line #{}: {}.".format(i, line))
         monotype = False
         raw_frame = _RawFrameData()
+        raw_frame.shapedef = collections.OrderedDict()
         raw_frame.view_rotation = None
         for i, line in enumerate(self.stream):
             if _is_comment(line):

--- a/glotzformats/posfilewriter.py
+++ b/glotzformats/posfilewriter.py
@@ -108,6 +108,8 @@ class PosFileWriter(object):
                         "Using fallback definition.".format(name))
                     _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION))
             except AttributeError:
+                # If AttributeError is raised because the frame does not contain
+                # shape information, fill them all with the default shape
                 for name in frame.types:
                     logger.info(
                         "No shape defined for '{}'. "

--- a/glotzformats/posfilewriter.py
+++ b/glotzformats/posfilewriter.py
@@ -95,17 +95,24 @@ class PosFileWriter(object):
             _write(' '.join((str(_num(v)) for v in box_matrix.flatten())))
 
             # shape defs
-            required = set(frame.types).intersection(
-                set(frame.shapedef.keys()))
-            not_defined = set(frame.types).difference(
-                set(frame.shapedef.keys()))
-            for name in required:
-                _write('def {} "{}"'.format(name, frame.shapedef[name]))
-            for name in not_defined:
-                logger.info(
-                    "No shape defined for '{}'. "
-                    "Using fallback definition.".format(name))
-                _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION))
+            try:
+                required = set(frame.types).intersection(
+                    set(frame.shapedef.keys()))
+                not_defined = set(frame.types).difference(
+                    set(frame.shapedef.keys()))
+                for name in required:
+                    _write('def {} "{}"'.format(name, frame.shapedef[name]))
+                for name in not_defined:
+                    logger.info(
+                        "No shape defined for '{}'. "
+                        "Using fallback definition.".format(name))
+                    _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION))
+            except AttributeError:
+                for name in frame.types:
+                    logger.info(
+                        "No shape defined for '{}'. "
+                        "Using fallback definition.".format(name))
+                    _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION))
 
             # Orientations must be provided for all particles
             # If the frame does not have orientations, identity quaternions are used
@@ -118,7 +125,10 @@ class PosFileWriter(object):
                                       orientations):
 
                 _write(name, end=' ')
-                shapedef = frame.shapedef.get(name, DEFAULT_SHAPE_DEFINITION)
+                try:
+                    shapedef = frame.shapedef.get(name)
+                except AttributeError:
+                    shapedef = DEFAULT_SHAPE_DEFINITION
 
                 if self._rotate and frame.view_rotation is not None:
                     pos = rowan.rotate(frame.view_rotation, pos)

--- a/glotzformats/trajectory.py
+++ b/glotzformats/trajectory.py
@@ -5,7 +5,6 @@ The trajectory module provides classes to store discretized
 trajectories."""
 
 import logging
-import collections
 
 import numpy as np
 
@@ -117,7 +116,7 @@ class FrameData(object):
         "A dictionary of lists for each attribute."
         self.data_keys = None
         "A list of strings, where each string represents one attribute."
-        self.shapedef = collections.OrderedDict()
+        self.shapedef = None
         "A ordered dictionary of instances of :class:`~.shapes.ShapeDefinition`."
         self.view_rotation = None
         "A quaternion specifying a rotation that should be applied for visualization."
@@ -184,7 +183,7 @@ class _RawFrameData(object):
         self.data = None
         self.data_keys = None                       # A list of strings
         # A ordered dictionary of instances of ShapeDefinition
-        self.shapedef = collections.OrderedDict()
+        self.shapedef = None
         # A view rotation (does not affect the actual trajectory)
         self.view_rotation = None
 

--- a/tests/test_dcdfilereader.py
+++ b/tests/test_dcdfilereader.py
@@ -58,6 +58,8 @@ class BaseDCDFileReaderTest(TrajectoryTest):
             frame.mass
         with self.assertRaises(AttributeError):
             frame.velocities
+        with self.assertRaises(AttributeError):
+            frame.shapedef
 
     def test_read(self):
         assert self.read_top_trajectory()

--- a/tests/test_gsdhoomdfilereader.py
+++ b/tests/test_gsdhoomdfilereader.py
@@ -4,7 +4,6 @@ import io
 import unittest
 import base64
 import numpy as np
-import collections
 
 import glotzformats
 from test_trajectory import TrajectoryTest

--- a/tests/test_gsdhoomdfilereader.py
+++ b/tests/test_gsdhoomdfilereader.py
@@ -86,7 +86,8 @@ class BaseGSDHOOMDFileReaderTest(TrajectoryTest):
     def test_gsd_without_pos_frame(self):
         frame, traj = self.get_gsd_traj_with_pos_frame(read_pos=False)
         assert frame is None
-        self.assertEqual(traj[0].shapedef, collections.OrderedDict())
+        with self.assertRaises(AttributeError):
+            frame.shapedef
 
     def test_read(self):
         traj = self.get_traj()

--- a/tests/test_pydcdfilereader.py
+++ b/tests/test_pydcdfilereader.py
@@ -79,5 +79,6 @@ class BaseDCDFileReaderTest(TrajectoryTest):
         for frame in traj:
             self.assert_raise_attribute_error(frame)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pydcdfilereader.py
+++ b/tests/test_pydcdfilereader.py
@@ -36,6 +36,24 @@ class BaseDCDFileReaderTest(TrajectoryTest):
         dcdfile = io.BytesIO(base64.b64decode(glotzformats.samples.DCD_BASE64))
         return self.reader().read(dcdfile, top_traj[0])
 
+    def assert_raise_attribute_error(self, frame):
+        with self.assertRaises(AttributeError):
+            frame.charge
+        with self.assertRaises(AttributeError):
+            frame.diameter
+        with self.assertRaises(AttributeError):
+            frame.moment_inertia
+        with self.assertRaises(AttributeError):
+            frame.angmom
+        with self.assertRaises(AttributeError):
+            frame.image
+        with self.assertRaises(AttributeError):
+            frame.mass
+        with self.assertRaises(AttributeError):
+            frame.velocities
+        with self.assertRaises(AttributeError):
+            frame.shapedef
+
     def test_read(self):
         traj = self.get_traj()
         self.assertEqual(len(traj), 10)
@@ -58,6 +76,8 @@ class BaseDCDFileReaderTest(TrajectoryTest):
             [1.78225398064, -0.266534328461, -1.39306223392],
             [0.162209749222, -2.22765517235, -1.27463591099]])))
 
+        for frame in traj:
+            self.assert_raise_attribute_error(frame)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves issue #57.  This PR changes the default value of  the `shapedef` attribute from `OrderedDict()` to `None`, which results in the raise of `AttributeError` for formats that do not support shape information. It also raises `AttributeError` in cases where shape information is missing from shape supporting formats.