### PR TITLE
Rename to garnett in hidden configuration files.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,7 +6,7 @@ message = Bump up to version {new_version}.
 
 [bumpversion:file:setup.py]
 
-[bumpversion:file:glotzformats/__init__.py]
+[bumpversion:file:garnett/__init__.py]
 
 [bumpversion:file:doc/conf.py]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: style-check
           command: |
             pip install --user -U flake8==3.7.1
-            python -m flake8 --show-source glotzformats/
+            python -m flake8 --show-source garnett/
 
 
   test-3.7: &test-template

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,11 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
-source = glotzformats
+source = garnett
 omit =
-    glotzformats/common/six.py
-    glotzformats/gsdhoomd.py
-    glotzformats/pygsd.py
+    garnett/common/six.py
+    garnett/gsdhoomd.py
+    garnett/pygsd.py
 
 [report]
 ignore_errors = True

--- a/.flake8
+++ b/.flake8
@@ -6,8 +6,8 @@ exclude =
     dist,
     doc/conf.py,
     examples,
-    glotzformats/common/six.py,
-    glotzformats/gsdhoomd.py,
-    glotzformats/pygsd.py,
+    garnett/common/six.py,
+    garnett/gsdhoomd.py,
+    garnett/pygsd.py,
     samples,
 max_line_length=120

--- a/garnett/errors.py
+++ b/garnett/errors.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
+
+
 class ParserError(RuntimeError):
     pass
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -65,8 +65,9 @@ class UtilReaderTest(unittest.TestCase):
             self.assertGreater(len(traj), 0)
 
     def test_read_gsd_template(self):
-        with garnett.read(get_filename('template-missing-shape.gsd'),
-                               template=get_filename('template-missing-shape.pos')) as traj:
+        with garnett.read(
+                get_filename('template-missing-shape.gsd'),
+                template=get_filename('template-missing-shape.pos')) as traj:
             self.assertGreater(len(traj), 0)
 
             # Make sure a shape definition was parsed from the POS file
@@ -74,8 +75,9 @@ class UtilReaderTest(unittest.TestCase):
 
     def test_read_unsupported_template(self):
         with self.assertRaises(ValueError):
-            with garnett.read(get_filename('FeSiUC.pos'),
-                                   template=get_filename('template-missing-shape.pos')):
+            with garnett.read(
+                    get_filename('FeSiUC.pos'),
+                    template=get_filename('template-missing-shape.pos')):
                 pass
 
     @unittest.skipIf(PYTHON_2, 'requires python 3')


### PR DESCRIPTION
I missed a few hidden configuration files when changing the name to garnett. This PR fixes those cases, for bumpversion, CircleCI, flake8, and coverage.