### PR TITLE
Fix namespace for mock import of dcdreader in documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -306,7 +306,7 @@ autodoc_mock_imports = [
     'numpy',
     'numpy.core',
     'numpy.core.numeric',
-    'dcdreader',
+    'garnett.dcdreader',
     'gtar',
     'CifFile',
     'gsd',


### PR DESCRIPTION
The API documentation isn't building on readthedocs, possibly due to interactions between `numpy` being mocked and the cython version of the DCD reader. This patch causes the dcd reader to be appropriately mocked on my machine.