### PR TITLE
Use pip requirements for all CI dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,14 +35,6 @@ jobs:
             python --version
             pip --version
             pip install --user -r .circleci/requirements.txt
-            pip install --user gsd==1.7.0 gtar
-            pip install --user -U coverage
-            python -c "import numpy; print('numpy', numpy.__version__)"
-            python -c "import cython; print('cython', cython.__version__)"
-            python -c "import gsd; print('gsd', gsd.__version__)"
-            python -c "import gtar; print('gtar', gtar.__version__)"
-            python -c "import rowan; print('rowan', rowan.__version__)"
-            python -c "import pkg_resources; print('pycifrw', pkg_resources.require('pycifrw')[0].version)"
             python setup.py build
 
       - run:

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,5 +1,8 @@
-numpy==1.16.1
 Cython==0.29.5
 PyCifRW==4.4
+coverage==4.5.4
 ddt==1.2.0
+gsd==1.7.0
+gtar==1.0.1
+numpy==1.16.1
 rowan==1.2.0


### PR DESCRIPTION
@lyrivera I moved all the CI dependencies into the requirements file, so that we know the exact versions we use and have a stable set of tests. Feel free to merge this PR into #117.