### PR TITLE
Fixed plato box primitive.

### DIFF
--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -381,7 +381,7 @@ class Frame(object):
         box = self.box
         if self.box.dimensions == 2:
             box.Lz = 0
-        prims.append(backend.Box(box=box))
+        prims.append(backend.Box.from_box(box, color=(0, 0, 0, 1)))
 
         # Create a shape primitive for each shape definition
         for type_name, type_shape in self.shapedef.items():


### PR DESCRIPTION
## Description
The API for the plato box primitive changed between when I created PR #120 and the release of plato v1.7.0. I didn't catch that until updating plato. This PR fixes it so that the `to_plato_scene` will work with the released version of plato.

## How Has This Been Tested?
I ran the plato scene tests locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst). (garnett hasn't been released since #120 so it's fine to keep the existing changelog line from #120)