### PR TITLE
Properly write default shape into POS files

### DIFF
--- a/garnett/posfilewriter.py
+++ b/garnett/posfilewriter.py
@@ -105,7 +105,7 @@ class PosFileWriter(object):
                     logger.info(
                         "No shape defined for '{}'. "
                         "Using fallback definition.".format(name))
-                    _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION))
+                    _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION.pos_string))
             except AttributeError:
                 # If AttributeError is raised because the frame does not contain
                 # shape information, fill them all with the default shape
@@ -113,7 +113,7 @@ class PosFileWriter(object):
                     logger.info(
                         "No shape defined for '{}'. "
                         "Using fallback definition.".format(name))
-                    _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION))
+                    _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION.pos_string))
 
             # Orientations must be provided for all particles
             # If the frame does not have orientations, identity quaternions are used

--- a/tests/test_posfilereaderwriter.py
+++ b/tests/test_posfilereaderwriter.py
@@ -12,6 +12,8 @@ from ddt import ddt, data
 import garnett
 import numpy as np
 from tempfile import TemporaryDirectory
+import base64
+from garnett.posfilewriter import DEFAULT_SHAPE_DEFINITION
 
 PATH = os.path.join(garnett.__path__[0], '..')
 IN_PATH = os.path.abspath(PATH) == os.path.abspath(os.getcwd())
@@ -161,6 +163,21 @@ class PosFileReaderTest(BasePosFileReaderTest):
         traj.load_arrays()
         self.assert_raise_attribute_error(traj)
 
+    def test_default(self):
+        with TemporaryDirectory() as tmp_dir:
+            gsdfile = 'testfile.gsd'
+            posfile = 'testfile.pos'
+            with open(gsdfile, "wb") as f:
+                f.write(base64.b64decode(garnett.samples.GSD_BASE64))
+            with garnett.read(gsdfile) as traj:
+                with self.assertRaises(AttributeError):
+                    traj[-1].shapedef
+                garnett.write(traj, posfile)
+            with garnett.read(posfile) as traj:
+                for frame in traj:
+                    for name in frame.shapedef.keys():
+                        self.assertEqual(frame.shapedef[name], \
+                                         DEFAULT_SHAPE_DEFINITION)
 
 @unittest.skipIf(not HPMC, 'requires HPMC')
 class HPMCPosFileReaderTest(BasePosFileReaderTest):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `PosFileWriter` was writing `__str__` representation of the default shape definition instead of the designated `pos_string` property.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: No corresponding issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test that performs read-write-read operation. First, a `gsd` file without shape definition is read and translated into a `pos` file. Then, the latter is read again to check that the default shape was properly written. All other tests are passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
