### PR TITLE
Change Trajectory and Frame API to be consistent with HOOMD conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import garnett
 # Autodetects file format for a uniform trajectory API
 with garnett.read('gsdfile.gsd') as traj:
     for frame in traj:
-        pos = frame.positions
+        pos = frame.position
 
 # Simple conversion of trajectory formats
 with garnett.read('posfile.pos') as traj:
@@ -64,9 +64,9 @@ sub_trajectory = traj[i:j]
 Access properties of trajectories:
 ```
 traj.load_arrays()
-traj.positions       # MxNx3
-traj.orientations    # MxNx4
-traj.velocities      # MxNx3
+traj.position        # MxNx3
+traj.orientation     # MxNx4
+traj.velocity        # MxNx3
 traj.mass            # MxN
 traj.charge          # MxN
 traj.diameter        # MxN
@@ -82,9 +82,9 @@ Access properties of individual frames:
 frame = traj[i]
 frame.box              # 3x3 matrix (not required to be upper-triangular)
 frame.types            # N
-frame.positions        # Nx3
-frame.orientations     # Nx4
-frame.velocities       # Nx3
+frame.position         # Nx3
+frame.orientation      # Nx4
+frame.velocity         # Nx3
 frame.mass             # N
 frame.charge           # N
 frame.diameter         # N

--- a/bin/garnett2pos
+++ b/bin/garnett2pos
@@ -66,16 +66,16 @@ def center_ld(frame):
     b = frame.box
     box = freud.box.Box(Lx=b.Lx, Ly=b.Ly, Lz=b.Lz, xy=b.xy,
                         xz=b.xz, yz=b.yz, is2D=b.dimensions == 2)
-    ld.compute(box, np.asarray(frame.positions, dtype=np.float32))
+    ld.compute(box, np.asarray(frame.position, dtype=np.float32))
     density = ld.getDensity()
     i_max = np.argmax(density)
-    frame.positions -= frame.positions[i_max]
+    frame.position -= frame.position[i_max]
     return frame
 
 
 def center(frame):
     import numpy as np
-    frame.positions -= np.mean(frame.positions, axis=0)
+    frame.position -= np.mean(frame.position, axis=0)
     return frame
 
 
@@ -83,10 +83,10 @@ def select_center(frame, s):
     import numpy as np
     b = np.diag(frame.box.get_box_matrix())
     b_ = b * s
-    select = (np.abs(frame.positions) < b_ / 2).all(axis=1)
+    select = (np.abs(frame.position) < b_ / 2).all(axis=1)
     frame.types = [t for i, t in enumerate(frame.types) if select[i]]
-    frame.positions = frame.positions[select]
-    frame.orientations = frame.orientations[select]
+    frame.position = frame.position[select]
+    frame.orientation = frame.orientation[select]
     frame.box.Lx = b_[0]
     frame.box.Ly = b_[1]
     frame.box.Lz = b_[2]
@@ -96,8 +96,8 @@ def select_center(frame, s):
 def wrap_into_box(frame):
     import numpy as np
     b = np.diag(frame.box.get_box_matrix())
-    images = np.round(frame.positions / b)
-    frame.positions -= images * b
+    images = np.round(frame.position / b)
+    frame.position -= images * b
     return frame
 
 
@@ -210,7 +210,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '-c', '--center',
         action='store_true',
-        help="Center particle positions.")
+        help="Center particle position.")
     parser.add_argument(
         '-d', '--center-by-density',
         action='store_true',

--- a/bin/garnett2pos
+++ b/bin/garnett2pos
@@ -210,7 +210,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '-c', '--center',
         action='store_true',
-        help="Center particle position.")
+        help="Center particle positions.")
     parser.add_argument(
         '-d', '--center-by-density',
         action='store_true',

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -75,16 +75,16 @@ The actual trajectory data is then either accessed on a *per trajectory* or *per
 Trajectory array access
 -----------------------
 
-Access positions, orientations and types as coherent numpy arrays, by calling the :py:meth:`~.trajectory.Trajectory.load_arrays` method.
-This method will load the complete trajectory into memory and make positions, orientations and types available via properties:
+Access position, orientation and types as coherent numpy arrays, by calling the :py:meth:`~.trajectory.Trajectory.load_arrays` method.
+This method will load the complete trajectory into memory and make position, orientation and types available via properties:
 
 .. code-block:: python
 
     traj.load_arrays()
     traj.N               # M
-    traj.positions       # MxNx3
-    traj.orientations    # MxNx4
-    traj.velocities      # MxNx3
+    traj.position       # MxNx3
+    traj.orientation    # MxNx4
+    traj.velocity      # MxNx3
     traj.mass            # MxN
     traj.charge          # MxN
     traj.diameter        # MxN
@@ -108,9 +108,9 @@ Inidividual frame objects can be accessed via indexing of a (sub-)trajectory obj
     frame = traj[i]
     frame.box              # garnett.trajectory.Box object
     frame.types            # N
-    frame.positions        # Nx3
-    frame.orientations     # Nx4
-    frame.velocities       # Nx3
+    frame.position        # Nx3
+    frame.orientation     # Nx4
+    frame.velocity       # Nx3
     frame.mass             # N
     frame.charge           # N
     frame.diameter         # N
@@ -130,7 +130,7 @@ Each frame will be loaded *prior* to access and unloaded *post* access, such tha
 
     # Iterate over a trajectory directly for read-only data access
     for frame in traj:
-        print(frame.positions)
+        print(frame.position)
 
 Efficient modification of trajectories
 ======================================
@@ -144,7 +144,7 @@ This is an example on how to modify frames in-place:
     import garnett as gt
 
     def center(frame):
-        frame.positions -= np.average(frame.positions, axis=0)
+        frame.position -= np.average(frame.position, axis=0)
         return frame
 
     with gt.read('in.pos') as traj:
@@ -161,12 +161,12 @@ This means that loading all trajectory data into memory requires an explicit cal
 
     # Make trajectory data accessible via arrays:
     traj.load_arrays()
-    traj.positions
+    traj.position
 
     # Load all frames:
     traj.load()
     frame = traj[i]
-    traj.positions    # load() also loads arrays
+    traj.position    # load() also loads arrays
 
 .. note::
 
@@ -179,7 +179,7 @@ Sub-trajectories inherit already loaded data:
 
     traj.load_arrays()
     sub_traj = traj[i:j]
-    sub_traj.positions
+    sub_traj.position
 
 .. tip::
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -75,7 +75,7 @@ The actual trajectory data is then either accessed on a *per trajectory* or *per
 Trajectory array access
 -----------------------
 
-Access position, orientation and types as coherent numpy arrays, by calling the :py:meth:`~.trajectory.Trajectory.load_arrays` method.
+Access to fields like position, orientation, and types as coherent numpy arrays, by calling the :py:meth:`~.trajectory.Trajectory.load_arrays` method.
 This method will load the complete trajectory into memory and make position, orientation and types available via properties:
 
 .. code-block:: python

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -82,9 +82,9 @@ This method will load the complete trajectory into memory and make position, ori
 
     traj.load_arrays()
     traj.N               # M
-    traj.position       # MxNx3
-    traj.orientation    # MxNx4
-    traj.velocity      # MxNx3
+    traj.position        # MxNx3
+    traj.orientation     # MxNx4
+    traj.velocity        # MxNx3
     traj.mass            # MxN
     traj.charge          # MxN
     traj.diameter        # MxN
@@ -108,9 +108,9 @@ Inidividual frame objects can be accessed via indexing of a (sub-)trajectory obj
     frame = traj[i]
     frame.box              # garnett.trajectory.Box object
     frame.types            # N
-    frame.position        # Nx3
-    frame.orientation     # Nx4
-    frame.velocity       # Nx3
+    frame.position         # Nx3
+    frame.orientation      # Nx4
+    frame.velocity         # Nx3
     frame.mass             # N
     frame.charge           # N
     frame.diameter         # N

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -75,8 +75,9 @@ The actual trajectory data is then either accessed on a *per trajectory* or *per
 Trajectory array access
 -----------------------
 
-Access to fields like position, orientation, and types as coherent numpy arrays, by calling the :py:meth:`~.trajectory.Trajectory.load_arrays` method.
-This method will load the complete trajectory into memory and make position, orientation and types available via properties:
+The complete trajectory may be loaded into memory by calling the :py:meth:`~.trajectory.Trajectory.load_arrays` method.
+This will allow access to fields such as position, orientation, and velocity across all frames and particles. 
+Supported properties are listed below:
 
 .. code-block:: python
 

--- a/doc/readerswriters.rst
+++ b/doc/readerswriters.rst
@@ -53,7 +53,7 @@ File Formats
 This table outlines the supported properties of each format reader and writer.
 
 +--------+-----------+-----+--------------+------------+-------+-----------------------------------+
-| Format | Position | Box | Orientation | Velocity | Shape | Additional Properties (See below) |
+| Format |  Position | Box |  Orientation |  Velocity  | Shape | Additional Properties (See below) |
 +--------+-----------+-----+--------------+------------+-------+-----------------------------------+
 |    POS |     RW    |  RW |      RW      |    N/A+    |   RW  |                N/A                |
 +--------+-----------+-----+--------------+------------+-------+-----------------------------------+

--- a/doc/readerswriters.rst
+++ b/doc/readerswriters.rst
@@ -53,7 +53,7 @@ File Formats
 This table outlines the supported properties of each format reader and writer.
 
 +--------+-----------+-----+--------------+------------+-------+-----------------------------------+
-| Format | position | Box | orientation | velocity | Shape | Additional Properties (See below) |
+| Format | Position | Box | Orientation | Velocity | Shape | Additional Properties (See below) |
 +--------+-----------+-----+--------------+------------+-------+-----------------------------------+
 |    POS |     RW    |  RW |      RW      |    N/A+    |   RW  |                N/A                |
 +--------+-----------+-----+--------------+------------+-------+-----------------------------------+

--- a/doc/readerswriters.rst
+++ b/doc/readerswriters.rst
@@ -144,7 +144,7 @@ DCD
 ---
 
 The *DCD*-format is a very storage efficient *binary* format for storing simple trajectory data.
-The format contains only data about xyz-position and the boxes of individual frames.
+The format contains only data about particle positions and the simulation boxes of individual frames.
 
 HOOMD-blue provides a writer for this format with a special dialect for 2-dimensional systems.
 The *garnett* dcd-reader is capable of reading both the standard and the 2-dim. dialect.

--- a/doc/readerswriters.rst
+++ b/doc/readerswriters.rst
@@ -53,7 +53,7 @@ File Formats
 This table outlines the supported properties of each format reader and writer.
 
 +--------+-----------+-----+--------------+------------+-------+-----------------------------------+
-| Format | Positions | Box | Orientations | Velocities | Shape | Additional Properties (See below) |
+| Format | position | Box | orientation | velocity | Shape | Additional Properties (See below) |
 +--------+-----------+-----+--------------+------------+-------+-----------------------------------+
 |    POS |     RW    |  RW |      RW      |    N/A+    |   RW  |                N/A                |
 +--------+-----------+-----+--------------+------------+-------+-----------------------------------+
@@ -144,7 +144,7 @@ DCD
 ---
 
 The *DCD*-format is a very storage efficient *binary* format for storing simple trajectory data.
-The format contains only data about xyz-positions and the boxes of individual frames.
+The format contains only data about xyz-position and the boxes of individual frames.
 
 HOOMD-blue provides a writer for this format with a special dialect for 2-dimensional systems.
 The *garnett* dcd-reader is capable of reading both the standard and the 2-dim. dialect.

--- a/examples/modify.py
+++ b/examples/modify.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def center(frame):
-    frame.positions -= np.average(frame.positions, axis=0)
+    frame.position -= np.average(frame.position, axis=0)
     return frame
 
 

--- a/garnett/ciffilereader.py
+++ b/garnett/ciffilereader.py
@@ -121,7 +121,7 @@ class CifFileFrame(Frame):
         """Extend parent function to also incorporate cif_coordinates"""
         ret = super(CifFileFrame, self)._raw_frame_to_frame(raw_frame, dtype)
         ret.cif_coordinates = np.asarray(raw_frame.cif_coordinates, dtype=dtype)
-        assert len(ret.positions) == len(ret.cif_coordinates)
+        assert len(ret.position) == len(ret.cif_coordinates)
         return ret
 
     def read(self):
@@ -202,7 +202,7 @@ class CifFileFrame(Frame):
         raw_frame = _RawFrameData()
         raw_frame.box = box_matrix
         raw_frame.types = unique_types
-        raw_frame.positions = coordinates
+        raw_frame.position = coordinates
         raw_frame.cif_coordinates = cif_coordinates
         return raw_frame
 

--- a/garnett/ciffilewriter.py
+++ b/garnett/ciffilewriter.py
@@ -67,7 +67,7 @@ class CifFileWriter(object):
         from . import __version__
 
         if occupancies is None:
-            occupancies = np.ones(frame.positions.shape[0])
+            occupancies = np.ones(frame.position.shape[0])
 
         def _write(msg='', end='\n'):
             file.write(msg + end)
@@ -108,14 +108,14 @@ class CifFileWriter(object):
             fractions = frame.cif_coordinates.copy()
         else:
             if fractional:
-                fractions = frame.positions.copy()
+                fractions = frame.position.copy()
             else:
                 invbox = np.linalg.inv(frame.box.get_box_matrix())
-                fractions = np.dot(invbox, frame.positions.T).T
+                fractions = np.dot(invbox, frame.position.T).T
             fractions += 0.5
 
         type_counter = defaultdict(int)
-        n_digits = len(str(len(frame.positions)))
+        n_digits = len(str(len(frame.position)))
         particle_str = "{ptype}{pnum:0" + str(n_digits) + "d} {ptype} {occ:3.2f} {position}"
         for i, (position, particle_type, occupancy) in enumerate(zip(fractions, frame.types, occupancies)):
             _write(particle_str.format(

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -25,7 +25,7 @@ The example is given for a hoomd-blue xml frame:
 .. note::
 
     If the topology frame is 2-dimensional, the dcd
-    trajectory position are interpreted such that
+    trajectory positions are interpreted such that
     the first two values contain the xy-coordinates,
     the third value is an euler angle.
 

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -5,7 +5,7 @@
 
 Authors: Carl Simon Adorf
 
-A dcd file conists only of positions.
+A dcd file conists only of position.
 To provide additional information it is possible
 to provide a frame object, whose properties
 are copied into each frame of the dcd trajectory.
@@ -25,7 +25,7 @@ The example is given for a hoomd-blue xml frame:
 .. note::
 
     If the topology frame is 2-dimensional, the dcd
-    trajectory positions are interpreted such that
+    trajectory position are interpreted such that
     the first two values contain the xy-coordinates,
     the third value is an euler angle.
 
@@ -36,7 +36,7 @@ The example is given for a hoomd-blue xml frame:
 
     .. code::
 
-        ort = traj[0].orientations
+        ort = traj[0].orientation
         alpha = 2 * np.arctan2(ort[:, 3], ort[:, 0])
 """
 
@@ -132,8 +132,8 @@ class DCDFrame(Frame):
         self.default_type = default_type
         self._types = None
         self._box = None
-        self._positions = None
-        self._orientations = None
+        self._position = None
+        self._orientation = None
         super(DCDFrame, self).__init__(dtype=dtype)
 
     def __len__(self):
@@ -143,7 +143,7 @@ class DCDFrame(Frame):
         frame_header = _DCDFrameHeader(
             ** self._dcdreader.read_frame(self.stream, xyz, self.offset))
         self._box = np.asarray(_box_matrix_from_frame_header(frame_header)).T
-        self._positions = xyz.swapaxes(0, 1)
+        self._position = xyz.swapaxes(0, 1)
 
     def _load(self, xyz=None, ort=None):
         N = int(self.file_header.n_particles)
@@ -161,17 +161,17 @@ class DCDFrame(Frame):
             ort.T[1:] = 0
         elif self.t_frame.box.dimensions == 2:
             _euler_to_quaternion(
-                self._positions.T[-1], ort)
-            self._positions.T[-1] = 0
+                self._position.T[-1], ort)
+            self._position.T[-1] = 0
         else:
             raise ValueError(self.t_frame.box.dimensions)
-        self._orientations = ort
+        self._orientation = ort
 
     def _loaded(self):
         return not (self._types is None or
                     self._box is None or
-                    self._positions is None or
-                    self._orientations is None)
+                    self._position is None or
+                    self._orientation is None)
 
     def read(self):
         raw_frame = _RawFrameData()
@@ -188,18 +188,18 @@ class DCDFrame(Frame):
         assert self._loaded()
         raw_frame.box = self._box
         raw_frame.types = copy.copy(self._types)
-        raw_frame.positions = self._positions
-        raw_frame.orientations = self._orientations
+        raw_frame.position = self._position
+        raw_frame.orientation = self._orientation
         assert len(raw_frame.types) == len(self)
-        assert len(raw_frame.positions) == len(self)
-        assert len(raw_frame.orientations) == len(self)
+        assert len(raw_frame.position) == len(self)
+        assert len(raw_frame.orientation) == len(self)
         return raw_frame
 
     def unload(self):
         self._types = None
         self._box = None
-        self._positions = None
-        self._orientations = None
+        self._position = None
+        self._orientation = None
         super(DCDFrame, self).unload()
 
     def __str__(self):
@@ -217,8 +217,8 @@ class DCDTrajectory(Trajectory):
                     self._type is None or
                     self._types is None or
                     self._type_ids is None or
-                    self._positions is None or
-                    self._orientations is None)
+                    self._position is None or
+                    self._orientation is None)
 
     def load_arrays(self):
         # Determine array shapes
@@ -244,12 +244,12 @@ class DCDTrajectory(Trajectory):
             self._type = _type
             self._types = types
             self._type_ids = type_ids
-            self._positions = xyz.swapaxes(1, 2)
-            self._orientations = ort
+            self._position = xyz.swapaxes(1, 2)
+            self._orientation = ort
         except Exception:
             # Ensure consistent error state
             self._N = self._type = self._types = self._type_ids = \
-                self._positions = self._orientations = None
+                self._position = self._orientation = None
             raise
 
     def xyz(self, xyz=None):

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -5,7 +5,7 @@
 
 Authors: Carl Simon Adorf
 
-A dcd file conists only of position.
+A dcd file consists only of positions.
 To provide additional information it is possible
 to provide a frame object, whose properties
 are copied into each frame of the dcd trajectory.

--- a/garnett/getarfilereader.py
+++ b/garnett/getarfilereader.py
@@ -49,11 +49,8 @@ class GetarFrame(Frame):
         raw_frame = _RawFrameData()
         raw_frame.shapedef = collections.OrderedDict()
         prop_map = {
-            'position': 'position',
-            'orientation': 'orientation',
-            'velocity': 'velocity',
             'angular_momentum_quat': 'angmom',
-            'image': 'image'}
+                    }
         supported_records = ['position', 'orientation', 'velocity',
                              'mass', 'charge', 'diameter',
                              'moment_inertia', 'angular_momentum_quat',

--- a/garnett/getarfilereader.py
+++ b/garnett/getarfilereader.py
@@ -158,7 +158,7 @@ class GetarFileReader(object):
             self._frames = _trajectory.queryFrames(_records['position'])
         except KeyError:
             raise RuntimeError("Given trajectory '{}' contained no "
-                               "position.".format(stream))
+                               "positions".format(stream))
         frames = [GetarFrame(_trajectory, _records, idx, default_type, default_box)
                   for idx in self._frames]
         logger.info("Read {} frames.".format(len(frames)))

--- a/garnett/getarfilereader.py
+++ b/garnett/getarfilereader.py
@@ -49,9 +49,9 @@ class GetarFrame(Frame):
         raw_frame = _RawFrameData()
         raw_frame.shapedef = collections.OrderedDict()
         prop_map = {
-            'position': 'positions',
-            'orientation': 'orientations',
-            'velocity': 'velocities',
+            'position': 'position',
+            'orientation': 'orientation',
+            'velocity': 'velocity',
             'angular_momentum_quat': 'angmom',
             'image': 'image'}
         supported_records = ['position', 'orientation', 'velocity',
@@ -76,7 +76,7 @@ class GetarFrame(Frame):
                 self._records['type'], self._frame)
             raw_frame.types = [names[t] for t in types]
         else:
-            raw_frame.types = len(raw_frame.positions) * [self._default_type]
+            raw_frame.types = len(raw_frame.position) * [self._default_type]
 
         if 'box' in self._records:
             # Read dimension if stored
@@ -85,7 +85,7 @@ class GetarFrame(Frame):
                              self._records['dimensions'], self._frame)[0]
             # Fallback to detection based on z coordinates
             else:
-                zs = raw_frame.positions[:, 2]
+                zs = raw_frame.position[:, 2]
                 dimensions = 2 if np.allclose(zs, 0.0, atol=1e-7) else 3
 
             box = self._trajectory.getRecord(self._records['box'], self._frame)
@@ -158,7 +158,7 @@ class GetarFileReader(object):
             self._frames = _trajectory.queryFrames(_records['position'])
         except KeyError:
             raise RuntimeError("Given trajectory '{}' contained no "
-                               "positions.".format(stream))
+                               "position.".format(stream))
         frames = [GetarFrame(_trajectory, _records, idx, default_type, default_box)
                   for idx in self._frames]
         logger.info("Read {} frames.".format(len(frames)))

--- a/garnett/getarfilereader.py
+++ b/garnett/getarfilereader.py
@@ -48,9 +48,7 @@ class GetarFrame(Frame):
     def read(self):
         raw_frame = _RawFrameData()
         raw_frame.shapedef = collections.OrderedDict()
-        prop_map = {
-            'angular_momentum_quat': 'angmom',
-                    }
+        prop_map = {'angular_momentum_quat': 'angmom'}
         supported_records = ['position', 'orientation', 'velocity',
                              'mass', 'charge', 'diameter',
                              'moment_inertia', 'angular_momentum_quat',

--- a/garnett/getarfilereader.py
+++ b/garnett/getarfilereader.py
@@ -153,7 +153,7 @@ class GetarFileReader(object):
             self._frames = _trajectory.queryFrames(_records['position'])
         except KeyError:
             raise RuntimeError("Given trajectory '{}' contained no "
-                               "positions".format(stream))
+                               "positions.".format(stream))
         frames = [GetarFrame(_trajectory, _records, idx, default_type, default_box)
                   for idx in self._frames]
         logger.info("Read {} frames.".format(len(frames)))

--- a/garnett/getarfilewriter.py
+++ b/garnett/getarfilewriter.py
@@ -41,9 +41,9 @@ class GetarFileWriter(object):
     """
 
     property_record_map = {
-        'positions': 'position.f32.ind',
-        'orientations': 'orientation.f32.ind',
-        'velocities': 'velocity.f32.ind',
+        'position': 'position.f32.ind',
+        'orientation': 'orientation.f32.ind',
+        'velocity': 'velocity.f32.ind',
         'mass': 'mass.f32.ind',
         'charge': 'charge.f32.ind',
         'diameter': 'diameter.f32.ind',

--- a/garnett/gsdhoomdfilereader.py
+++ b/garnett/gsdhoomdfilereader.py
@@ -227,9 +227,9 @@ class GSDHoomdFrame(Frame):
         raw_frame.box = _box_matrix(frame.configuration.box)
         raw_frame.box_dimensions = int(frame.configuration.dimensions)
         raw_frame.types = [frame.particles.types[t] for t in frame.particles.typeid]
-        raw_frame.positions = frame.particles.position
-        raw_frame.orientations = frame.particles.orientation
-        raw_frame.velocities = frame.particles.velocity
+        raw_frame.position = frame.particles.position
+        raw_frame.orientation = frame.particles.orientation
+        raw_frame.velocity = frame.particles.velocity
         raw_frame.mass = frame.particles.mass
         raw_frame.charge = frame.particles.charge
         raw_frame.diameter = frame.particles.diameter

--- a/garnett/gsdhoomdfilewriter.py
+++ b/garnett/gsdhoomdfilewriter.py
@@ -128,15 +128,15 @@ class GSDHOOMDFileWriter(object):
                 except AttributeError:
                     pass
                 try:
-                    snap.particles.position = frame.positions
+                    snap.particles.position = frame.position
                 except AttributeError:
                     pass
                 try:
-                    snap.particles.orientation = frame.orientations
+                    snap.particles.orientation = frame.orientation
                 except AttributeError:
                     pass
                 try:
-                    snap.particles.velocity = frame.velocities
+                    snap.particles.velocity = frame.velocity
                 except AttributeError:
                     pass
                 try:

--- a/garnett/gsdhoomdfilewriter.py
+++ b/garnett/gsdhoomdfilewriter.py
@@ -123,46 +123,21 @@ class GSDHOOMDFileWriter(object):
                 except AttributeError:
                     types = ['A']
                 snap.particles.types = types
-                try:
-                    snap.particles.typeid = [types.index(typeid) for typeid in frame.types]
-                except AttributeError:
-                    pass
-                try:
-                    snap.particles.position = frame.position
-                except AttributeError:
-                    pass
-                try:
-                    snap.particles.orientation = frame.orientation
-                except AttributeError:
-                    pass
-                try:
-                    snap.particles.velocity = frame.velocity
-                except AttributeError:
-                    pass
-                try:
-                    snap.particles.mass = frame.mass
-                except AttributeError:
-                    pass
-                try:
-                    snap.particles.charge = frame.charge
-                except AttributeError:
-                    pass
-                try:
-                    snap.particles.diameter = frame.diameter
-                except AttributeError:
-                    pass
-                try:
-                    snap.particles.moment_inertia = frame.moment_inertia
-                except AttributeError:
-                    pass
-                try:
-                    snap.particles.angmom = frame.angmom
-                except AttributeError:
-                    pass
-                try:
-                    snap.particles.image = frame.image
-                except AttributeError:
-                    pass
+                for prop in [
+                        'position',
+                        'orientation',
+                        'velocity',
+                        'mass',
+                        'charge',
+                        'diameter',
+                        'moment_intertia',
+                        'angmom',
+                        'image'
+                        ]:
+                    try:
+                        setattr(snap.particles, prop, getattr(frame, prop))
+                    except AttributeError:
+                        pass
                 snap.configuration.box = frame.box.get_box_array()
                 snap.configuration.dimensions = frame.box.dimensions
                 try:

--- a/garnett/gsdhoomdfilewriter.py
+++ b/garnett/gsdhoomdfilewriter.py
@@ -123,17 +123,7 @@ class GSDHOOMDFileWriter(object):
                 except AttributeError:
                     types = ['A']
                 snap.particles.types = types
-                for prop in [
-                        'position',
-                        'orientation',
-                        'velocity',
-                        'mass',
-                        'charge',
-                        'diameter',
-                        'moment_intertia',
-                        'angmom',
-                        'image'
-                        ]:
+                for prop in trajectory.TRAJ_ATTRIBUTES[4:]:
                     try:
                         setattr(snap.particles, prop, getattr(frame, prop))
                     except AttributeError:
@@ -147,4 +137,3 @@ class GSDHOOMDFileWriter(object):
                     pass
                 traj_outfile.append(snap)
                 logger.debug("Wrote frame {}.".format(i + 1))
-        logger.info("Wrote {} frames.".format(i + 1))

--- a/garnett/hoomdxmlfilereader.py
+++ b/garnett/hoomdxmlfilereader.py
@@ -92,7 +92,7 @@ def _parse_position(position):
     for i, position_str in enumerate(position.text.splitlines()[1:]):
         yield [float(x) for x in position_str.split()]
     if i + 1 != int(position.attrib.get('num', i + 1)):
-        warnings.warn("Number of position inconsistent.")
+        warnings.warn("Number of positions is inconsistent.")
 
 
 def _parse_velocity(velocity):

--- a/garnett/hoomdxmlfilereader.py
+++ b/garnett/hoomdxmlfilereader.py
@@ -37,13 +37,13 @@ class HOOMDXMLFrame(Frame):
         config = self.root.find('configuration')
         raw_frame.box = np.asarray(_get_box_matrix(config.find('box')))
         raw_frame.box_dimensions = int(config.get('dimensions', 3))
-        raw_frame.positions = list(_parse_positions(config.find('position')))
-        orientations = config.find('orientation')
-        if orientations is not None:
-            raw_frame.orientations = list(_parse_orientations(orientations))
-        velocities = config.find('velocity')
-        if velocities is not None:
-            raw_frame.velocities = list(_parse_velocities(velocities))
+        raw_frame.position = list(_parse_position(config.find('position')))
+        orientation = config.find('orientation')
+        if orientation is not None:
+            raw_frame.orientation = list(_parse_orientation(orientation))
+        velocity = config.find('velocity')
+        if velocity is not None:
+            raw_frame.velocity = list(_parse_velocity(velocity))
 
         raw_frame.types = list(_parse_types(config.find('type')))
         return raw_frame
@@ -88,25 +88,25 @@ def _get_box_matrix(box):
     ]
 
 
-def _parse_positions(positions):
-    for i, position in enumerate(positions.text.splitlines()[1:]):
+def _parse_position(position):
+    for i, position in enumerate(position.text.splitlines()[1:]):
         yield [float(x) for x in position.split()]
-    if i + 1 != int(positions.attrib.get('num', i + 1)):
-        warnings.warn("Number of positions inconsistent.")
+    if i + 1 != int(position.attrib.get('num', i + 1)):
+        warnings.warn("Number of position inconsistent.")
 
 
-def _parse_velocities(velocities):
-    for i, velocity in enumerate(velocities.text.splitlines()[1:]):
+def _parse_velocity(velocity):
+    for i, velocity in enumerate(velocity.text.splitlines()[1:]):
         yield [float(x) for x in velocity.split()]
-    if i + 1 != int(velocities.attrib.get('num', i + 1)):
-        warnings.warn("Number of velocities inconsistent.")
+    if i + 1 != int(velocity.attrib.get('num', i + 1)):
+        warnings.warn("Number of velocity inconsistent.")
 
 
-def _parse_orientations(orientations):
-    for i, orientation in enumerate(orientations.text.splitlines()[1:]):
+def _parse_orientation(orientation):
+    for i, orientation in enumerate(orientation.text.splitlines()[1:]):
         yield [float(x) for x in orientation.split()]
-    if i + 1 != int(orientations.attrib.get('num', i + 1)):
-        warnings.warn("Number of orientations inconsistent.")
+    if i + 1 != int(orientation.attrib.get('num', i + 1)):
+        warnings.warn("Number of orientation inconsistent.")
 
 
 def _parse_types(types):

--- a/garnett/hoomdxmlfilereader.py
+++ b/garnett/hoomdxmlfilereader.py
@@ -89,22 +89,22 @@ def _get_box_matrix(box):
 
 
 def _parse_position(position):
-    for i, position in enumerate(position.text.splitlines()[1:]):
-        yield [float(x) for x in position.split()]
+    for i, position_str in enumerate(position.text.splitlines()[1:]):
+        yield [float(x) for x in position_str.split()]
     if i + 1 != int(position.attrib.get('num', i + 1)):
         warnings.warn("Number of position inconsistent.")
 
 
 def _parse_velocity(velocity):
-    for i, velocity in enumerate(velocity.text.splitlines()[1:]):
-        yield [float(x) for x in velocity.split()]
+    for i, velocity_str in enumerate(velocity.text.splitlines()[1:]):
+        yield [float(x) for x in velocity_str.split()]
     if i + 1 != int(velocity.attrib.get('num', i + 1)):
         warnings.warn("Number of velocity inconsistent.")
 
 
 def _parse_orientation(orientation):
-    for i, orientation in enumerate(orientation.text.splitlines()[1:]):
-        yield [float(x) for x in orientation.split()]
+    for i, orientation_str in enumerate(orientation.text.splitlines()[1:]):
+        yield [float(x) for x in orientation_str.split()]
     if i + 1 != int(orientation.attrib.get('num', i + 1)):
         warnings.warn("Number of orientation inconsistent.")
 

--- a/garnett/hoomdxmlfilereader.py
+++ b/garnett/hoomdxmlfilereader.py
@@ -106,11 +106,11 @@ def _parse_orientation(orientation):
     for i, orientation_str in enumerate(orientation.text.splitlines()[1:]):
         yield [float(x) for x in orientation_str.split()]
     if i + 1 != int(orientation.attrib.get('num', i + 1)):
-        warnings.warn("Number of orientation inconsistent.")
+        warnings.warn("Number of orientations is inconsistent.")
 
 
 def _parse_types(types):
     for i, type in enumerate(types.text.splitlines()[1:]):
         yield str(type)
     if i + 1 != int(types.attrib.get('num', i)):
-        warnings.warn("Number of types inconsistent.")
+        warnings.warn("Number of types is inconsistent.")

--- a/garnett/hoomdxmlfilereader.py
+++ b/garnett/hoomdxmlfilereader.py
@@ -99,7 +99,7 @@ def _parse_velocity(velocity):
     for i, velocity_str in enumerate(velocity.text.splitlines()[1:]):
         yield [float(x) for x in velocity_str.split()]
     if i + 1 != int(velocity.attrib.get('num', i + 1)):
-        warnings.warn("Number of velocity inconsistent.")
+        warnings.warn("Number of velocities is inconsistent.")
 
 
 def _parse_orientation(orientation):

--- a/garnett/posfilereader.py
+++ b/garnett/posfilereader.py
@@ -109,7 +109,7 @@ class PosFileFrame(Frame):
             num_centers = int(next(tokens))
             vertices = [[] for p in range(num_centers)]
             centers = []
-            orientations = []
+            orientation = []
             colors = []
             for i in range(num_centers):
                 num_vertices = int(next(tokens))
@@ -119,11 +119,11 @@ class PosFileFrame(Frame):
                 xyz = next(tokens), next(tokens), next(tokens)
                 centers.append([self._num(v) for v in xyz])
                 quat = next(tokens), next(tokens), next(tokens), next(tokens)
-                orientations.append([self._num(q) for q in quat])
+                orientation.append([self._num(q) for q in quat])
                 colors.append(next(tokens))
             return ConvexPolyhedronUnionShape(vertices=vertices,
                                               centers=centers,
-                                              orientations=orientations,
+                                              orientation=orientation,
                                               colors=colors)
         elif shape_class.lower() == 'polyv':  # Officially polyV
             num_vertices = int(next(tokens))
@@ -296,29 +296,29 @@ class PosFileFrame(Frame):
                     else:
                         raise ParserError(line)
                     raw_frame.types.append(name)
-                    raw_frame.positions.append([self._num(v) for v in xyz])
+                    raw_frame.position.append([self._num(v) for v in xyz])
                     if quat is None:
-                        raw_frame.orientations.append(quat)
+                        raw_frame.orientation.append(quat)
                     else:
-                        raw_frame.orientations.append([self._num(v) for v in quat])
+                        raw_frame.orientation.append([self._num(v) for v in quat])
 
         # Perform inverse rotation to recover original coordinates
         if raw_frame.view_rotation is not None:
-            pos = rowan.rotate(rowan.inverse(raw_frame.view_rotation), raw_frame.positions)
+            pos = rowan.rotate(rowan.inverse(raw_frame.view_rotation), raw_frame.position)
         else:
-            pos = np.asarray(raw_frame.positions)
+            pos = np.asarray(raw_frame.position)
         # If all the z coordinates are close to zero, set box dimension to 2
         if np.allclose(pos[:, 2], 0.0, atol=1e-7):
             raw_frame.box_dimensions = 2
 
         # If no valid orientations have been added, the array should be empty
-        if all([quat is None for quat in raw_frame.orientations]):
-            raw_frame.orientations = []
+        if all([quat is None for quat in raw_frame.orientation]):
+            raw_frame.orientation = []
         else:
             # Replace values of None with an identity quaternion
-            for i in range(len(raw_frame.orientations)):
-                if raw_frame.orientations[i] is None:
-                    raw_frame.orientations[i] = [1, 0, 0, 0]
+            for i in range(len(raw_frame.orientation)):
+                if raw_frame.orientation[i] is None:
+                    raw_frame.orientation[i] = [1, 0, 0, 0]
         return raw_frame
 
     def __str__(self):

--- a/garnett/posfilereader.py
+++ b/garnett/posfilereader.py
@@ -109,7 +109,7 @@ class PosFileFrame(Frame):
             num_centers = int(next(tokens))
             vertices = [[] for p in range(num_centers)]
             centers = []
-            orientation = []
+            orientations = []
             colors = []
             for i in range(num_centers):
                 num_vertices = int(next(tokens))
@@ -119,11 +119,11 @@ class PosFileFrame(Frame):
                 xyz = next(tokens), next(tokens), next(tokens)
                 centers.append([self._num(v) for v in xyz])
                 quat = next(tokens), next(tokens), next(tokens), next(tokens)
-                orientation.append([self._num(q) for q in quat])
+                orientations.append([self._num(q) for q in quat])
                 colors.append(next(tokens))
             return ConvexPolyhedronUnionShape(vertices=vertices,
                                               centers=centers,
-                                              orientation=orientation,
+                                              orientations=orientations,
                                               colors=colors)
         elif shape_class.lower() == 'polyv':  # Officially polyV
             num_vertices = int(next(tokens))

--- a/garnett/posfilewriter.py
+++ b/garnett/posfilewriter.py
@@ -116,12 +116,9 @@ class PosFileWriter(object):
                     _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION.pos_string))
 
             # Orientations must be provided for all particles
-            # If the frame does not have orientations, identity quaternions are used
-            try:
-                orientation = frame.orientation
-            except AttributeError:
-                orientation = np.array([[1, 0, 0, 0]] * len(frame.types))
-
+            # If the frame does not have orientations, identity quaternions are use
+            orientation = getattr(frame, 'orientation', np.array([[1, 0, 0, 0]] * len(frame.types)))
+            
             for name, pos, rot in zip(frame.types, frame.position,
                                       orientation):
 

--- a/garnett/posfilewriter.py
+++ b/garnett/posfilewriter.py
@@ -118,7 +118,7 @@ class PosFileWriter(object):
             # Orientations must be provided for all particles
             # If the frame does not have orientations, identity quaternions are use
             orientation = getattr(frame, 'orientation', np.array([[1, 0, 0, 0]] * len(frame.types)))
-            
+
             for name, pos, rot in zip(frame.types, frame.position,
                                       orientation):
 

--- a/garnett/posfilewriter.py
+++ b/garnett/posfilewriter.py
@@ -116,11 +116,10 @@ class PosFileWriter(object):
                     _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION.pos_string))
 
             # Orientations must be provided for all particles
-            # If the frame does not have orientations, identity quaternions are use
+            # If the frame does not have orientations, identity quaternions are used
             orientation = getattr(frame, 'orientation', np.array([[1, 0, 0, 0]] * len(frame.types)))
 
-            for name, pos, rot in zip(frame.types, frame.position,
-                                      orientation):
+            for name, pos, rot in zip(frame.types, frame.position, orientation):
 
                 _write(name, end=' ')
                 try:

--- a/garnett/posfilewriter.py
+++ b/garnett/posfilewriter.py
@@ -118,12 +118,12 @@ class PosFileWriter(object):
             # Orientations must be provided for all particles
             # If the frame does not have orientations, identity quaternions are used
             try:
-                orientations = frame.orientations
+                orientation = frame.orientation
             except AttributeError:
-                orientations = np.array([[1, 0, 0, 0]] * len(frame.types))
+                orientation = np.array([[1, 0, 0, 0]] * len(frame.types))
 
-            for name, pos, rot in zip(frame.types, frame.positions,
-                                      orientations):
+            for name, pos, rot in zip(frame.types, frame.position,
+                                      orientation):
 
                 _write(name, end=' ')
                 try:

--- a/garnett/shapes.py
+++ b/garnett/shapes.py
@@ -341,18 +341,18 @@ class ConvexPolyhedronUnionShape(Shape):
         list
     """
 
-    def __init__(self, vertices, centers, orientation, colors=None):
+    def __init__(self, vertices, centers, orientations, colors=None):
         super(ConvexPolyhedronUnionShape, self).__init__(
             shape_class='poly3d_union', color='')
         self.vertices = vertices
         self.centers = centers
-        self.orientation = orientation
+        self.orientations = orientations
         self.colors = colors
 
     @property
     def pos_string(self):
         shape_def = '{} {} '.format(self.shape_class, len(self.centers))
-        for verts, p, q, c in zip(self.vertices, self.centers, self.orientation, self.colors):
+        for verts, p, q, c in zip(self.vertices, self.centers, self.orientations, self.colors):
             shape_def += '{0} '.format(len(verts))
             for v in verts:
                 shape_def += '{0} {1} {2} '.format(*v)

--- a/garnett/shapes.py
+++ b/garnett/shapes.py
@@ -341,18 +341,18 @@ class ConvexPolyhedronUnionShape(Shape):
         list
     """
 
-    def __init__(self, vertices, centers, orientations, colors=None):
+    def __init__(self, vertices, centers, orientation, colors=None):
         super(ConvexPolyhedronUnionShape, self).__init__(
             shape_class='poly3d_union', color='')
         self.vertices = vertices
         self.centers = centers
-        self.orientations = orientations
+        self.orientation = orientation
         self.colors = colors
 
     @property
     def pos_string(self):
         shape_def = '{} {} '.format(self.shape_class, len(self.centers))
-        for verts, p, q, c in zip(self.vertices, self.centers, self.orientations, self.colors):
+        for verts, p, q, c in zip(self.vertices, self.centers, self.orientation, self.colors):
             shape_def += '{0} '.format(len(verts))
             for v in verts:
                 shape_def += '{0} {1} {2} '.format(*v)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -1380,6 +1380,14 @@ def to_hoomd_snapshot(frame, snapshot=None):
     return snapshot
 
 
+def copy_to_hoomd_blue_snapshot(frame, snapshot=None):
+    warnings.warn(
+            "This function was renamed to {}. {} will be removed in version 0.8.0.".format("to_hoomd_snapshot(frame, snapshot)", "copy_to_hoomd_blue_snapshot(frame, snapshot)"),
+            DeprecationWarning
+            )
+    return to_hoomd_snapshot(frame, snapshot)
+
+
 def copyfrom_hoomd_blue_snapshot(frame, snapshot):
     """"Copy the HOOMD-blue snapshot into the frame.
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -329,7 +329,7 @@ class Frame(object):
     def copyto_snapshot(self, snapshot):
         "Copy this frame to a HOOMD-blue snapshot."
         self.load()
-        return copyto_hoomd_blue_snapshot(self.frame_data, snapshot)
+        return to_hoomd_snapshot(self.frame_data, snapshot)
 
     def to_plato_scene(self, backend, scene=None):
         """Create a plato scene from this frame.

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -8,6 +8,7 @@ The trajectory module provides classes to store discretized
 trajectories."""
 
 import logging
+import warnings
 
 import numpy as np
 import rowan
@@ -215,6 +216,13 @@ class Frame(object):
             raise AttributeError('{} not available for this frame'.format(attr))
         else:
             return value
+
+    def _deprecation_warning(self, old_attr, new_attr):
+        warnings.warn(
+            "This property was renamed to %s. %s will be removed in version 0.6.3" %
+            (new_attr, old_attr),
+            DeprecationWarning
+        )
 
     def _raw_frame_to_frame(self, raw_frame, dtype=None):
         """Generate a frame object from a raw frame object."""
@@ -499,6 +507,15 @@ class Frame(object):
         self.load()
         return self._raise_attributeerror('position')
 
+    @property
+    def positions(self):
+        """
+        Nx3 array of coordinated for N particles in 3 dimensions.
+        Deprecated alias for position.
+        """
+        self._deprecation_warning('positions', 'position')
+        return self.position(self)
+
     @position.setter
     def position(self, value):
         # Various sanity checks
@@ -521,6 +538,15 @@ class Frame(object):
         self.load()
         return self._raise_attributeerror('orientation')
 
+    @property
+    def orientations(self):
+        """
+        Nx4 array of rotational coordinates for N particles represented as quaternions.
+        Deprecated alias for orientation.
+        """
+        self._deprecation_warning('orientations', 'orientation')
+        return self.orientation(self)
+
     @orientation.setter
     def orientation(self, value):
         try:
@@ -540,6 +566,15 @@ class Frame(object):
         "Nx3 array of velocities for N particles in 3 dimensions."
         self.load()
         return self._raise_attributeerror('velocity')
+
+    @property
+    def velocities(self):
+        """
+        Nx3 array of velocities for N particles in 3 dimensions.
+        Deprecated alias for velocity.
+        """
+        self._deprecation_warning('velocities', 'velocity')
+        return self.velocity(self)
 
     @velocity.setter
     def velocity(self, value):
@@ -905,6 +940,13 @@ class Trajectory(BaseTrajectory):
         "Returns the size of the largest frame within this trajectory."
         return max((len(f) for f in self.frames))
 
+    def _deprecation_warning(self, old_attr, new_attr):
+        warnings.warn(
+            "This property was renamed to %s. %s will be removed in version 0.6.3" %
+            (new_attr, old_attr),
+            DeprecationWarning
+        )
+
     def load_arrays(self):
         """Load positions, orientations and types into memory.
 
@@ -1102,6 +1144,14 @@ class Trajectory(BaseTrajectory):
         return self._check_nonempty_property('_position')
 
     @property
+    def positions(self):
+        """
+        Deprecated alias for position.
+        """
+        self._deprecation_warning('positions', 'position')
+        return self.position(self)
+
+    @property
     def orientation(self):
         """Access the particle orientations as a numpy array.
 
@@ -1116,6 +1166,12 @@ class Trajectory(BaseTrajectory):
         return self._check_nonempty_property('_orientation')
 
     @property
+    def orientations(self):
+        """Deprecated alias for orientation."""
+        self._deprecation_warning('orientations', 'orientation')
+        return self.orientation(self)
+
+    @property
     def velocity(self):
         """Access the particle velocities as a numpy array.
 
@@ -1126,6 +1182,12 @@ class Trajectory(BaseTrajectory):
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
         return self._check_nonempty_property('_velocity')
+
+    @property
+    def velocities(self):
+        """Deprecated alias for velocity."""
+        self._deprecation_warning('velocities', 'velocity')
+        return self.velocity(self)
 
     @property
     def mass(self):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -1276,7 +1276,7 @@ def _generate_type_id_array(types, type_ids):
     return _type
 
 
-def copy_to_hoomd_blue_snapshot(frame, snapshot=None):
+def copyto_hoomd_blue_snapshot(frame, snapshot=None):
     "Copy the frame into a HOOMD-blue snapshot."
     if frame.position is not None:
         np.copyto(snapshot.particles.position, frame.position)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -165,7 +165,7 @@ class FrameData(object):
 
     def copyto_snapshot(self, snapshot):
         "Copy this frame to a HOOMD-blue snapshot."
-        return copy_to_hoomd_blue_snapshot(self, snapshot)
+        return copyto_hoomd_blue_snapshot(self, snapshot)
 
 
 class _RawFrameData(object):
@@ -344,7 +344,7 @@ class Frame(object):
     def copyto_snapshot(self, snapshot):
         "Copy this frame to a HOOMD-blue snapshot."
         self.load()
-        return copy_to_hoomd_blue_snapshot(self.frame_data, snapshot)
+        return copyto_hoomd_blue_snapshot(self.frame_data, snapshot)
 
     def to_plato_scene(self, backend, scene=None):
         """Create a plato scene from this frame.
@@ -1339,4 +1339,4 @@ def make_hoomd_blue_snapshot(frame):
     np.copyto(
         snapshot.particles.typeid,
         np.array(type_ids, dtype=snapshot.particles.typeid.dtype))
-    return copy_to_hoomd_blue_snapshot(frame, snapshot)
+    return copyto_hoomd_blue_snapshot(frame, snapshot)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -1445,8 +1445,8 @@ def from_hoomd_snapshot(frame, snapshot):
 def copyfrom_hoomd_blue_snapshot(frame, snapshot):
     warnings.warn(
         "This function was renamed to {}. {} will be removed in version 0.8.0.".format(
-            "to_hoomd_snapshot(frame, snapshot)",
-            "copy_to_hoomd_blue_snapshot(frame, snapshot)"
+            "from_hoomd_snapshot(frame, snapshot)",
+            "copyfrom_hoomd_blue_snapshot(frame, snapshot)"
         ),
         DeprecationWarning
     )

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -246,7 +246,8 @@ class Frame(object):
     def _deprecation_warning(self, old_attr, new_attr):
         warnings.warn(
             "This property was renamed to {}. {} will be removed in version 0.8.0.".format(new_attr, old_attr),
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
 
     def _raw_frame_to_frame(self, raw_frame, dtype=None):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -526,14 +526,14 @@ class Frame(object):
     @position.setter
     def position(self, value):
         # Various sanity checks
-        value = self._validate_input_array(value, self.box.dimensions)
+        value = self._validate_input_array(value, 3)
         self.load()
         self.frame_data.position = value
 
     @positions.setter
     def positions(self, value):
         # Various sanity checks
-        value = self._validate_input_array(value, self.box.dimensions)
+        value = self._validate_input_array(value, 3)
         self.load()
         self.frame_data.position = value
 
@@ -584,13 +584,13 @@ class Frame(object):
 
     @velocity.setter
     def velocity(self, value):
-        self._validate_input_array(value, self.box.dimensions)
+        self._validate_input_array(value, 3)
         self.load()
         self.frame_data.velocity = value
 
     @velocities.setter
     def velocities(self, value):
-        self._validate_input_array(value, self.box.dimensions)
+        self._validate_input_array(value, 3)
         self.load()
         self.frame_data.velocity = value
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -263,11 +263,11 @@ class Frame(object):
             raw_frame.box_dimensions = raw_frame.box.dimensions
             raw_frame.box = np.asarray(raw_frame.box.get_box_matrix(), dtype=dtype)
         box_dimensions = getattr(raw_frame, 'box_dimensions', 3)
-        mapping["position"], mapping["velocity"], mapping["orientation"],\
-            mapping["angmom"], ret.box = _regularize_box(mapping["position"],
-                                                         mapping["velocity"],
-                                                         mapping["orientation"],
-                                                         mapping["angmom"],
+        mapping['position'], mapping['velocity'], mapping['orientation'],\
+            mapping['angmom'], ret.box = _regularize_box(mapping['position'],
+                                                         mapping['velocity'],
+                                                         mapping['orientation'],
+                                                         mapping['angmom'],
                                                          raw_frame.box,
                                                          dtype,
                                                          box_dimensions)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -282,24 +282,10 @@ class Frame(object):
         ret.data = raw_frame.data
         ret.data_keys = raw_frame.data_keys
         ret.view_rotation = raw_frame.view_rotation
-        assert N == len(ret.types)
-        assert N == len(ret.position)
-        if ret.orientation is not None:
-            assert N == len(ret.orientation)
-        if ret.velocity is not None:
-            assert N == len(ret.velocity)
-        if ret.mass is not None:
-            assert N == len(ret.mass)
-        if ret.charge is not None:
-            assert N == len(ret.charge)
-        if ret.diameter is not None:
-            assert N == len(ret.diameter)
-        if ret.moment_inertia is not None:
-            assert N == len(ret.moment_inertia)
-        if ret.angmom is not None:
-            assert N == len(ret.angmom)
-        if ret.image is not None:
-            assert N == len(ret.image)
+        # validate data
+        for prop in FRAME_ATTRIBUTES:
+            if getattr(ret, prop) is not None:
+                assert N == len(getattr(ret, prop))
         return ret
 
     def _validate_input_array(self, value, size):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -513,13 +513,26 @@ class Frame(object):
         Deprecated alias for position.
         """
         self._deprecation_warning('positions', 'position')
-        try:
-            return self.position(self)
-        except TypeError:
-            return self.position
+        return self.position
 
     @position.setter
     def position(self, value):
+        # Various sanity checks
+        try:
+            value = np.asarray(value, dtype=self._dtype)
+        except ValueError:
+            raise ValueError("position can only be set to numeric arrays.")
+        if not np.all(np.isfinite(value)):
+            raise ValueError("position being set must all be finite numbers.")
+        elif not len(value.shape) == 2 or value.shape[1] != self.box.dimensions:
+            raise ValueError("Input array must be of shape (N,{}) where N is the "
+                             "number of particles.".format(self.box.dimensions))
+
+        self.load()
+        self.frame_data.position = value
+
+    @positions.setter
+    def positions(self, value):
         # Various sanity checks
         try:
             value = np.asarray(value, dtype=self._dtype)
@@ -566,6 +579,20 @@ class Frame(object):
         self.load()
         self.frame_data.orientation = value
 
+    @orientations.setter
+    def orientations(self, value):
+        try:
+            value = np.asarray(value, dtype=self._dtype)
+        except ValueError:
+            raise ValueError("orientation can only be set to numeric arrays.")
+        if not np.all(np.isfinite(value)):
+            raise ValueError("orientation being set must all be finite numbers.")
+        elif not len(value.shape) == 2 or value.shape[1] != 4:
+            raise ValueError("Input array must be of shape (N,4) where N is the number of particles.")
+
+        self.load()
+        self.frame_data.orientation = value
+
     @property
     def velocity(self):
         "Nx3 array of velocities for N particles in 3 dimensions."
@@ -579,13 +606,24 @@ class Frame(object):
         Deprecated alias for velocity.
         """
         self._deprecation_warning('velocities', 'velocity')
-        try:
-            return self.velocity(self)
-        except TypeError:
-            return self.velocity
+        return self.velocity
 
     @velocity.setter
     def velocity(self, value):
+        try:
+            value = np.asarray(value, dtype=self._dtype)
+        except ValueError:
+            raise ValueError("velocity can only be set to numeric arrays.")
+        if not np.all(np.isfinite(value)):
+            raise ValueError("velocity being set must all be finite numbers.")
+        elif not len(value.shape) == 2 or value.shape[1] != self.box.dimensions:
+            raise ValueError("Input array must be of shape (N,{}) where N is the "
+                             "number of particles.".format(self.box.dimensions))
+        self.load()
+        self.frame_data.velocity = value
+
+    @velocities.setter
+    def velocities(self, value):
         try:
             value = np.asarray(value, dtype=self._dtype)
         except ValueError:
@@ -1158,10 +1196,7 @@ class Trajectory(BaseTrajectory):
         Deprecated alias for position.
         """
         self._deprecation_warning('positions', 'position')
-        try:
-            return self.position(self)
-        except TypeError:
-            return self.position
+        return self.position
 
     @property
     def orientation(self):
@@ -1181,10 +1216,7 @@ class Trajectory(BaseTrajectory):
     def orientations(self):
         """Deprecated alias for orientation."""
         self._deprecation_warning('orientations', 'orientation')
-        try:
-            return self.orientation(self)
-        except TypeError:
-            return self.orientation
+        return self.orientation
 
     @property
     def velocity(self):
@@ -1202,10 +1234,7 @@ class Trajectory(BaseTrajectory):
     def velocities(self):
         """Deprecated alias for velocity."""
         self._deprecation_warning('velocities', 'velocity')
-        try:
-            return self.velocity(self)
-        except TypeError:
-            return self.velocity
+        return self.velocity
 
     @property
     def mass(self):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -228,7 +228,7 @@ class Frame(object):
         else:
             return value
 
-    def _validate_input_array(self, value, dim=None, nelem=None):
+    def _validate_input_array(self, value, dim, nelem=None):
         try:
             value = np.asarray(value, dtype=self._dtype)
         except ValueError:
@@ -237,7 +237,7 @@ class Frame(object):
             raise ValueError("Property being set must all be finite numbers.")
         elif len(value.shape) != dim:
             raise ValueError("Input array must be {}-dimensional".format(dim))
-        elif dim == 2 and value.shape[0] != nelem:
+        elif dim == 2 and value.shape[1] != nelem:
             raise ValueError("Input array must be of shape (N,{}) where N is the number of particles.".format(nelem))
         return value
 
@@ -251,7 +251,7 @@ class Frame(object):
         """Generate a frame object from a raw frame object."""
         N = len(raw_frame.types)
         ret = FrameData()
-        
+
         mapping = dict()
         for prop in self.FRAME_ATTRIBUTES:
             mapping[prop] = np.asarray(getattr(raw_frame, prop), dtype=dtype)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -205,16 +205,15 @@ class Frame(object):
     """
     FRAME_ATTRIBUTES = [
             'position',
-            'orientation', 
-            'velocity', 
-            'mass', 
+            'orientation',
+            'velocity',
+            'mass',
             'charge',
-            'diameter', 
-            'moment_inertia', 
-            'angmom', 
+            'diameter',
+            'moment_inertia',
+            'angmom',
             'image'
             ]
-        
 
     def __init__(self, dtype=None):
         if dtype is None:
@@ -252,10 +251,10 @@ class Frame(object):
             raw_frame.box = np.asarray(raw_frame.box.get_box_matrix(), dtype=dtype)
         box_dimensions = getattr(raw_frame, 'box_dimensions', 3)
         ret.position, ret.velocity, ret.orientation, ret.angmom, ret.box = _regularize_box(
-            mapping['position'], 
-            mapping['velocity'], 
-            mapping['orientation'], 
-            mapping['angmom'], 
+            mapping['position'],
+            mapping['velocity'],
+            mapping['orientation'],
+            mapping['angmom'],
             raw_frame.box, dtype, box_dimensions)
 
         for prop in self.FRAME_ATTRIBUTES:

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -165,7 +165,7 @@ class FrameData(object):
 
     def copyto_snapshot(self, snapshot):
         "Copy this frame to a HOOMD-blue snapshot."
-        return to_hoomd_snapshot(self, snapshot)
+        return copy_to_hoomd_blue_snapshot(self, snapshot)
 
 
 class _RawFrameData(object):
@@ -343,7 +343,7 @@ class Frame(object):
     def copyto_snapshot(self, snapshot):
         "Copy this frame to a HOOMD-blue snapshot."
         self.load()
-        return to_hoomd_snapshot(self.frame_data, snapshot)
+        return copy_to_hoomd_blue_snapshot(self.frame_data, snapshot)
 
     def to_plato_scene(self, backend, scene=None):
         """Create a plato scene from this frame.

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -238,38 +238,68 @@ class Frame(object):
         """Generate a frame object from a raw frame object."""
         N = len(raw_frame.types)
         ret = FrameData()
-
-        mapping = dict()
-        for prop in self.FRAME_ATTRIBUTES:
-            mapping[prop] = np.asarray(getattr(raw_frame, prop), dtype=dtype)
-            if len(mapping[prop]) == 0:
-                mapping[prop] = None
-
+        position = np.asarray(raw_frame.position, dtype=dtype)
+        if len(position) == 0:
+            position = None
+        orientation = np.asarray(raw_frame.orientation, dtype=dtype)
+        if len(orientation) == 0:
+            orientation = None
+        velocity = np.asarray(raw_frame.velocity, dtype=dtype)
+        if len(velocity) == 0:
+            velocity = None
+        mass = np.asarray(raw_frame.mass, dtype=dtype)
+        if len(mass) == 0:
+            mass = None
+        charge = np.asarray(raw_frame.charge, dtype=dtype)
+        if len(charge) == 0:
+            charge = None
+        diameter = np.asarray(raw_frame.diameter, dtype=dtype)
+        if len(diameter) == 0:
+            diameter = None
+        moment_inertia = np.asarray(raw_frame.moment_inertia, dtype=dtype)
+        if len(moment_inertia) == 0:
+            moment_inertia = None
+        angmom = np.asarray(raw_frame.angmom, dtype=dtype)
+        if len(angmom) == 0:
+            angmom = None
+        image = np.asarray(raw_frame.image, dtype=np.int32)
+        if len(image) == 0:
+            image = None
         assert raw_frame.box is not None
         if isinstance(raw_frame.box, Box):
             raw_frame.box_dimensions = raw_frame.box.dimensions
             raw_frame.box = np.asarray(raw_frame.box.get_box_matrix(), dtype=dtype)
         box_dimensions = getattr(raw_frame, 'box_dimensions', 3)
         ret.position, ret.velocity, ret.orientation, ret.angmom, ret.box = _regularize_box(
-            mapping['position'],
-            mapping['velocity'],
-            mapping['orientation'],
-            mapping['angmom'],
-            raw_frame.box, dtype, box_dimensions)
-
-        for prop in self.FRAME_ATTRIBUTES:
-            setattr(ret, prop, mapping[prop])
-            if getattr(ret, prop) is not None:
-                assert N == len(getattr(ret, prop))
-
+            position, velocity, orientation, angmom, raw_frame.box, dtype, box_dimensions)
+        ret.mass = mass
+        ret.charge = charge
+        ret.diameter = diameter
+        ret.moment_inertia = moment_inertia
+        ret.image = image
         ret.shapedef = raw_frame.shapedef
         ret.types = raw_frame.types
         ret.data = raw_frame.data
         ret.data_keys = raw_frame.data_keys
         ret.view_rotation = raw_frame.view_rotation
-
         assert N == len(ret.types)
         assert N == len(ret.position)
+        if ret.orientation is not None:
+            assert N == len(ret.orientation)
+        if ret.velocity is not None:
+            assert N == len(ret.velocity)
+        if ret.mass is not None:
+            assert N == len(ret.mass)
+        if ret.charge is not None:
+            assert N == len(ret.charge)
+        if ret.diameter is not None:
+            assert N == len(ret.diameter)
+        if ret.moment_inertia is not None:
+            assert N == len(ret.moment_inertia)
+        if ret.angmom is not None:
+            assert N == len(ret.angmom)
+        if ret.image is not None:
+            assert N == len(ret.image)
         return ret
 
     def loaded(self):
@@ -1382,7 +1412,10 @@ def to_hoomd_snapshot(frame, snapshot=None):
 
 def copy_to_hoomd_blue_snapshot(frame, snapshot=None):
     warnings.warn(
-            "This function was renamed to {}. {} will be removed in version 0.8.0.".format("to_hoomd_snapshot(frame, snapshot)", "copy_to_hoomd_blue_snapshot(frame, snapshot)"),
+            "This function was renamed to {}. {} will be removed in version 0.8.0.".format(
+                "to_hoomd_snapshot(frame, snapshot)",
+                "copy_to_hoomd_blue_snapshot(frame, snapshot)"
+                ),
             DeprecationWarning
             )
     return to_hoomd_snapshot(frame, snapshot)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -228,17 +228,19 @@ class Frame(object):
         else:
             return value
 
-    def _validate_input_array(self, value, dim, nelem=None):
+    def _validate_input_array(self, value, dim, nelem=None, dtype=None):
+        if dtype is None:
+            dtype = self._dtype
         try:
-            value = np.asarray(value, dtype=self._dtype)
+            value = np.asarray(value, dtype=dtype)
         except ValueError:
             raise ValueError("This property can only be set to numeric arrays.")
         if not np.all(np.isfinite(value)):
             raise ValueError("Property being set must all be finite numbers.")
         elif len(value.shape) != dim:
-            raise ValueError("Input array must be {}-dimensional".format(dim))
+            raise ValueError("Input array must be {}-dimensional.".format(dim))
         elif dim == 2 and value.shape[1] != nelem:
-            raise ValueError("Input array must be of shape (N,{}) where N is the number of particles.".format(nelem))
+            raise ValueError("Input array must be of shape (N, {}) where N is the number of particles.".format(nelem))
         return value
 
     def _deprecation_warning(self, old_attr, new_attr):
@@ -634,7 +636,7 @@ class Frame(object):
 
     @image.setter
     def image(self, value):
-        value = self._validate_input_array(value, dim=2, nelem=3)
+        value = self._validate_input_array(value, dim=2, nelem=3, dtype=np.int32)
         self.load()
         self.frame_data.image = value
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -219,7 +219,7 @@ class Frame(object):
 
     def _deprecation_warning(self, old_attr, new_attr):
         warnings.warn(
-            "This property was renamed to %s. %s will be removed in version 0.6.3" %
+            "This property was renamed to %s. %s will be removed in version 0.8.0." %
             (new_attr, old_attr),
             DeprecationWarning
         )

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -500,7 +500,7 @@ class Frame(object):
     @property
     def positions(self):
         """
-        Nx3 array of coordinated for N particles in 3 dimensions.
+        Nx3 array of coordinates for N particles in 3 dimensions.
         Deprecated alias for position.
         """
         self._deprecation_warning('positions', 'position')

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -1275,7 +1275,7 @@ def _generate_type_id_array(types, type_ids):
     return _type
 
 
-def to_hoomd_snapshot(frame, snapshot=None):
+def copy_to_hoomd_blue_snapshot(frame, snapshot=None):
     "Copy the frame into a HOOMD-blue snapshot."
     if frame.position is not None:
         np.copyto(snapshot.particles.position, frame.position)
@@ -1298,18 +1298,7 @@ def to_hoomd_snapshot(frame, snapshot=None):
     return snapshot
 
 
-def copy_to_hoomd_blue_snapshot(frame, snapshot=None):
-    warnings.warn(
-            "This function was renamed to {}. {} will be removed in version 0.8.0.".format(
-                "to_hoomd_snapshot(frame, snapshot)",
-                "copy_to_hoomd_blue_snapshot(frame, snapshot)"
-                ),
-            DeprecationWarning
-            )
-    return to_hoomd_snapshot(frame, snapshot)
-
-
-def from_hoomd_snapshot(frame, snapshot):
+def copyfrom_hoomd_blue_snapshot(frame, snapshot):
     """"Copy the HOOMD-blue snapshot into the frame.
 
     Note that only the properties listed below will be copied.
@@ -1328,17 +1317,6 @@ def from_hoomd_snapshot(frame, snapshot):
     frame.angmom = snapshot.particles.angmom
     frame.image = snapshot.particles.image
     return frame
-
-
-def copyfrom_hoomd_blue_snapshot(frame, snapshot):
-    warnings.warn(
-        "This function was renamed to {}. {} will be removed in version 0.8.0.".format(
-            "from_hoomd_snapshot(frame, snapshot)",
-            "copyfrom_hoomd_blue_snapshot(frame, snapshot)"
-        ),
-        DeprecationWarning
-    )
-    return from_hoomd_snapshot(frame, snapshot)
 
 
 def make_hoomd_blue_snapshot(frame):
@@ -1360,4 +1338,4 @@ def make_hoomd_blue_snapshot(frame):
     np.copyto(
         snapshot.particles.typeid,
         np.array(type_ids, dtype=snapshot.particles.typeid.dtype))
-    return to_hoomd_snapshot(frame, snapshot)
+    return copy_to_hoomd_blue_snapshot(frame, snapshot)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -283,7 +283,7 @@ class Frame(object):
         ret.data_keys = raw_frame.data_keys
         ret.view_rotation = raw_frame.view_rotation
         # validate data
-        for prop in FRAME_ATTRIBUTES:
+        for prop in self.FRAME_ATTRIBUTES:
             if getattr(ret, prop) is not None:
                 assert N == len(getattr(ret, prop))
         return ret

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -514,7 +514,10 @@ class Frame(object):
         Deprecated alias for position.
         """
         self._deprecation_warning('positions', 'position')
-        return self.position(self)
+        try:
+            return self.position(self)
+        except TypeError:
+            return self.position
 
     @position.setter
     def position(self, value):
@@ -545,7 +548,10 @@ class Frame(object):
         Deprecated alias for orientation.
         """
         self._deprecation_warning('orientations', 'orientation')
-        return self.orientation(self)
+        try:
+            return self.orientation(self)
+        except TypeError:
+            return self.orientation
 
     @orientation.setter
     def orientation(self, value):
@@ -574,7 +580,10 @@ class Frame(object):
         Deprecated alias for velocity.
         """
         self._deprecation_warning('velocities', 'velocity')
-        return self.velocity(self)
+        try:
+            return self.velocity(self)
+        except TypeError:
+            return self.velocity
 
     @velocity.setter
     def velocity(self, value):
@@ -1149,7 +1158,10 @@ class Trajectory(BaseTrajectory):
         Deprecated alias for position.
         """
         self._deprecation_warning('positions', 'position')
-        return self.position(self)
+        try:
+            return self.position(self)
+        except TypeError:
+            return self.position
 
     @property
     def orientation(self):
@@ -1169,7 +1181,10 @@ class Trajectory(BaseTrajectory):
     def orientations(self):
         """Deprecated alias for orientation."""
         self._deprecation_warning('orientations', 'orientation')
-        return self.orientation(self)
+        try:
+            return self.orientation(self)
+        except TypeError:
+            return self.orientation
 
     @property
     def velocity(self):
@@ -1187,7 +1202,10 @@ class Trajectory(BaseTrajectory):
     def velocities(self):
         """Deprecated alias for velocity."""
         self._deprecation_warning('velocities', 'velocity')
-        return self.velocity(self)
+        try:
+            return self.velocity(self)
+        except TypeError:
+            return self.velocity
 
     @property
     def mass(self):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -1387,7 +1387,7 @@ def _generate_type_id_array(types, type_ids):
     return _type
 
 
-def copyto_hoomd_blue_snapshot(frame, snapshot):
+def to_hoomd_snapshot(frame, snapshot=None):
     "Copy the frame into a HOOMD-blue snapshot."
     if frame.position is not None:
         np.copyto(snapshot.particles.position, frame.position)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -165,7 +165,7 @@ class FrameData(object):
 
     def copyto_snapshot(self, snapshot):
         "Copy this frame to a HOOMD-blue snapshot."
-        return copyto_hoomd_blue_snapshot(self, snapshot)
+        return to_hoomd_snapshot(self, snapshot)
 
 
 class _RawFrameData(object):
@@ -1420,4 +1420,4 @@ def make_hoomd_blue_snapshot(frame):
     np.copyto(
         snapshot.particles.typeid,
         np.array(type_ids, dtype=snapshot.particles.typeid.dtype))
-    return copyto_hoomd_blue_snapshot(frame, snapshot)
+    return to_hoomd_snapshot(frame, snapshot)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -203,6 +203,18 @@ class Frame(object):
 
     :param dtype: The data type for frame data.
     """
+    FRAME_ATTRIBUTES = [
+            'position',
+            'orientation', 
+            'velocity', 
+            'mass', 
+            'charge',
+            'diameter', 
+            'moment_inertia', 
+            'angmom', 
+            'image'
+            ]
+        
 
     def __init__(self, dtype=None):
         if dtype is None:
@@ -228,41 +240,11 @@ class Frame(object):
         N = len(raw_frame.types)
         ret = FrameData()
 
-        position = np.asarray(raw_frame.position, dtype=dtype)
-        if len(position) == 0:
-            position = None
-
-        orientation = np.asarray(raw_frame.orientation, dtype=dtype)
-        if len(orientation) == 0:
-            orientation = None
-
-        velocity = np.asarray(raw_frame.velocity, dtype=dtype)
-        if len(velocity) == 0:
-            velocity = None
-
-        mass = np.asarray(raw_frame.mass, dtype=dtype)
-        if len(mass) == 0:
-            mass = None
-
-        charge = np.asarray(raw_frame.charge, dtype=dtype)
-        if len(charge) == 0:
-            charge = None
-
-        diameter = np.asarray(raw_frame.diameter, dtype=dtype)
-        if len(diameter) == 0:
-            diameter = None
-
-        moment_inertia = np.asarray(raw_frame.moment_inertia, dtype=dtype)
-        if len(moment_inertia) == 0:
-            moment_inertia = None
-
-        angmom = np.asarray(raw_frame.angmom, dtype=dtype)
-        if len(angmom) == 0:
-            angmom = None
-
-        image = np.asarray(raw_frame.image, dtype=np.int32)
-        if len(image) == 0:
-            image = None
+        mapping = dict()
+        for prop in self.FRAME_ATTRIBUTES:
+            mapping[prop] = np.asarray(getattr(raw_frame, prop), dtype=dtype)
+            if len(mapping[prop]) == 0:
+                mapping[prop] = None
 
         assert raw_frame.box is not None
         if isinstance(raw_frame.box, Box):
@@ -270,12 +252,17 @@ class Frame(object):
             raw_frame.box = np.asarray(raw_frame.box.get_box_matrix(), dtype=dtype)
         box_dimensions = getattr(raw_frame, 'box_dimensions', 3)
         ret.position, ret.velocity, ret.orientation, ret.angmom, ret.box = _regularize_box(
-            position, velocity, orientation, angmom, raw_frame.box, dtype, box_dimensions)
-        ret.mass = mass
-        ret.charge = charge
-        ret.diameter = diameter
-        ret.moment_inertia = moment_inertia
-        ret.image = image
+            mapping['position'], 
+            mapping['velocity'], 
+            mapping['orientation'], 
+            mapping['angmom'], 
+            raw_frame.box, dtype, box_dimensions)
+
+        for prop in self.FRAME_ATTRIBUTES:
+            setattr(ret, prop, mapping[prop])
+            if getattr(ret, prop) is not None:
+                assert N == len(getattr(ret, prop))
+
         ret.shapedef = raw_frame.shapedef
         ret.types = raw_frame.types
         ret.data = raw_frame.data
@@ -284,22 +271,6 @@ class Frame(object):
 
         assert N == len(ret.types)
         assert N == len(ret.position)
-        if ret.orientation is not None:
-            assert N == len(ret.orientation)
-        if ret.velocity is not None:
-            assert N == len(ret.velocity)
-        if ret.mass is not None:
-            assert N == len(ret.mass)
-        if ret.charge is not None:
-            assert N == len(ret.charge)
-        if ret.diameter is not None:
-            assert N == len(ret.diameter)
-        if ret.moment_inertia is not None:
-            assert N == len(ret.moment_inertia)
-        if ret.angmom is not None:
-            assert N == len(ret.angmom)
-        if ret.image is not None:
-            assert N == len(ret.image)
         return ret
 
     def loaded(self):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -251,45 +251,28 @@ class Frame(object):
         """Generate a frame object from a raw frame object."""
         N = len(raw_frame.types)
         ret = FrameData()
-        position = np.asarray(raw_frame.position, dtype=dtype)
-        if len(position) == 0:
-            position = None
-        orientation = np.asarray(raw_frame.orientation, dtype=dtype)
-        if len(orientation) == 0:
-            orientation = None
-        velocity = np.asarray(raw_frame.velocity, dtype=dtype)
-        if len(velocity) == 0:
-            velocity = None
-        mass = np.asarray(raw_frame.mass, dtype=dtype)
-        if len(mass) == 0:
-            mass = None
-        charge = np.asarray(raw_frame.charge, dtype=dtype)
-        if len(charge) == 0:
-            charge = None
-        diameter = np.asarray(raw_frame.diameter, dtype=dtype)
-        if len(diameter) == 0:
-            diameter = None
-        moment_inertia = np.asarray(raw_frame.moment_inertia, dtype=dtype)
-        if len(moment_inertia) == 0:
-            moment_inertia = None
-        angmom = np.asarray(raw_frame.angmom, dtype=dtype)
-        if len(angmom) == 0:
-            angmom = None
-        image = np.asarray(raw_frame.image, dtype=np.int32)
-        if len(image) == 0:
-            image = None
+        
+        mapping = dict()
+        for prop in self.FRAME_ATTRIBUTES:
+            mapping[prop] = np.asarray(getattr(raw_frame, prop), dtype=dtype)
+            if len(mapping[prop]) == 0:
+                mapping[prop] = None
+
         assert raw_frame.box is not None
         if isinstance(raw_frame.box, Box):
             raw_frame.box_dimensions = raw_frame.box.dimensions
             raw_frame.box = np.asarray(raw_frame.box.get_box_matrix(), dtype=dtype)
         box_dimensions = getattr(raw_frame, 'box_dimensions', 3)
-        ret.position, ret.velocity, ret.orientation, ret.angmom, ret.box = _regularize_box(
-            position, velocity, orientation, angmom, raw_frame.box, dtype, box_dimensions)
-        ret.mass = mass
-        ret.charge = charge
-        ret.diameter = diameter
-        ret.moment_inertia = moment_inertia
-        ret.image = image
+        mapping["position"], mapping["velocity"], mapping["orientation"],\
+            mapping["angmom"], ret.box = _regularize_box(mapping["position"],
+                                                         mapping["velocity"],
+                                                         mapping["orientation"],
+                                                         mapping["angmom"],
+                                                         raw_frame.box,
+                                                         dtype,
+                                                         box_dimensions)
+        for prop in self.FRAME_ATTRIBUTES:
+            setattr(ret, prop, mapping[prop])
         ret.shapedef = raw_frame.shapedef
         ret.types = raw_frame.types
         ret.data = raw_frame.data

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -879,7 +879,7 @@ class Trajectory(BaseTrajectory):
             "This property was renamed to {}. {} will be removed in "
             "version 0.8.0.".format(new_attr, old_attr),
             DeprecationWarning,
-            stacklevel=1
+            stacklevel=2
         )
 
     def load_arrays(self):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -951,7 +951,7 @@ class Trajectory(BaseTrajectory):
 
     def _deprecation_warning(self, old_attr, new_attr):
         warnings.warn(
-            "This property was renamed to %s. %s will be removed in version 0.6.3" %
+            "This property was renamed to %s. %s will be removed in version 0.8.0" %
             (new_attr, old_attr),
             DeprecationWarning,
             stacklevel=1

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -302,6 +302,17 @@ class Frame(object):
             assert N == len(ret.image)
         return ret
 
+    def _validate_input_array(self, value, size):
+        try:
+            value = np.asarray(value, dtype=self._dtype)
+        except ValueError:
+            raise ValueError("This property can only be set to numeric arrays.")
+        if not np.all(np.isfinite(value)):
+            raise ValueError("Property being set must all be finite numbers.")
+        elif not len(value.shape) == 2 or value.shape[1] != size:
+            raise ValueError("Input array must be of shape (N,{}) where N is the number of particles.".format(size))
+        return value
+
     def loaded(self):
         "Returns True if the frame is loaded into memory."
         return self.frame_data is not None
@@ -518,32 +529,14 @@ class Frame(object):
     @position.setter
     def position(self, value):
         # Various sanity checks
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("position can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("position being set must all be finite numbers.")
-        elif not len(value.shape) == 2 or value.shape[1] != self.box.dimensions:
-            raise ValueError("Input array must be of shape (N,{}) where N is the "
-                             "number of particles.".format(self.box.dimensions))
-
+        value = self._validate_input_array(value, self.box.dimensions)
         self.load()
         self.frame_data.position = value
 
     @positions.setter
     def positions(self, value):
         # Various sanity checks
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("position can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("position being set must all be finite numbers.")
-        elif not len(value.shape) == 2 or value.shape[1] != self.box.dimensions:
-            raise ValueError("Input array must be of shape (N,{}) where N is the "
-                             "number of particles.".format(self.box.dimensions))
-
+        value = self._validate_input_array(value, self.box.dimensions)
         self.load()
         self.frame_data.position = value
 
@@ -567,29 +560,13 @@ class Frame(object):
 
     @orientation.setter
     def orientation(self, value):
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("orientation can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("orientation being set must all be finite numbers.")
-        elif not len(value.shape) == 2 or value.shape[1] != 4:
-            raise ValueError("Input array must be of shape (N,4) where N is the number of particles.")
-
+        self._validate_input_array(value, 4)
         self.load()
         self.frame_data.orientation = value
 
     @orientations.setter
     def orientations(self, value):
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("orientation can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("orientation being set must all be finite numbers.")
-        elif not len(value.shape) == 2 or value.shape[1] != 4:
-            raise ValueError("Input array must be of shape (N,4) where N is the number of particles.")
-
+        self._validate_input_array(value, 4)
         self.load()
         self.frame_data.orientation = value
 
@@ -610,29 +587,13 @@ class Frame(object):
 
     @velocity.setter
     def velocity(self, value):
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("velocity can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("velocity being set must all be finite numbers.")
-        elif not len(value.shape) == 2 or value.shape[1] != self.box.dimensions:
-            raise ValueError("Input array must be of shape (N,{}) where N is the "
-                             "number of particles.".format(self.box.dimensions))
+        self._validate_input_array(value, self.box.dimensions)
         self.load()
         self.frame_data.velocity = value
 
     @velocities.setter
     def velocities(self, value):
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("velocity can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("velocity being set must all be finite numbers.")
-        elif not len(value.shape) == 2 or value.shape[1] != self.box.dimensions:
-            raise ValueError("Input array must be of shape (N,{}) where N is the "
-                             "number of particles.".format(self.box.dimensions))
+        self._validate_input_array(value, self.box.dimensions)
         self.load()
         self.frame_data.velocity = value
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -876,8 +876,8 @@ class Trajectory(BaseTrajectory):
 
     def _deprecation_warning(self, old_attr, new_attr):
         warnings.warn(
-            "This property was renamed to %s. %s will be removed in version 0.8.0" %
-            (new_attr, old_attr),
+            "This property was renamed to {}. {} will be removed in "
+            "version 0.8.0.".format(new_attr, old_attr),
             DeprecationWarning,
             stacklevel=1
         )

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -1421,7 +1421,7 @@ def copy_to_hoomd_blue_snapshot(frame, snapshot=None):
     return to_hoomd_snapshot(frame, snapshot)
 
 
-def copyfrom_hoomd_blue_snapshot(frame, snapshot):
+def from_hoomd_snapshot(frame, snapshot):
     """"Copy the HOOMD-blue snapshot into the frame.
 
     Note that only the properties listed below will be copied.
@@ -1440,6 +1440,17 @@ def copyfrom_hoomd_blue_snapshot(frame, snapshot):
     frame.angmom = snapshot.particles.angmom
     frame.image = snapshot.particles.image
     return frame
+
+
+def copyfrom_hoomd_blue_snapshot(frame, snapshot):
+    warnings.warn(
+        "This function was renamed to {}. {} will be removed in version 0.8.0.".format(
+            "to_hoomd_snapshot(frame, snapshot)",
+            "copy_to_hoomd_blue_snapshot(frame, snapshot)"
+        ),
+        DeprecationWarning
+    )
+    return from_hoomd_snapshot(frame, snapshot)
 
 
 def make_hoomd_blue_snapshot(frame):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -953,7 +953,8 @@ class Trajectory(BaseTrajectory):
         warnings.warn(
             "This property was renamed to %s. %s will be removed in version 0.6.3" %
             (new_attr, old_attr),
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=1
         )
 
     def load_arrays(self):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -107,7 +107,7 @@ class FrameData(object):
         self.orientation = None
         "Nx4 array of rotational coordinates for N particles represented as quaternions."
         self.velocity = None
-        "Nx3 array of velocity for N particles in 3 dimensions."
+        "Nx3 array of velocities for N particles in 3 dimensions."
         self.mass = None
         "Nx1 array of masses for N particles."
         self.charge = None
@@ -178,9 +178,9 @@ class _RawFrameData(object):
         self.box = None
         self.box_dimensions = 3
         self.types = list()                         # Nx1
-        self.position = list()                     # Nx3
-        self.orientation = list()                  # Nx4
-        self.velocity = list()                    # Nx3
+        self.position = list()                      # Nx3
+        self.orientation = list()                   # Nx4
+        self.velocity = list()                      # Nx3
         self.mass = list()                          # Nx1
         self.charge = list()                        # Nx1
         self.diameter = list()                      # Nx1

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -381,52 +381,52 @@ class Frame(object):
             if isinstance(type_shape, SphereShape):
                 if dimensions == 3:
                     prim = backend.Spheres(
-                        position=self.position[subset],
+                        positions=self.position[subset],
                         colors=make_default_colors(N_prim),
                         radii=[0.5 * type_shape['diameter']] * N_prim,
                     )
                 else:
                     prim = backend.Disks(
-                        position=self.position[subset, :2],
+                        positions=self.position[subset, :2],
                         colors=make_default_colors(N_prim),
                         radii=[0.5 * type_shape['diameter']] * N_prim,
                     )
             elif isinstance(type_shape, SphereUnionShape):
                 if dimensions == 3:
                     prim = backend.SphereUnions(
-                        position=self.position[subset],
-                        orientation=self.orientation[subset],
+                        positions=self.position[subset],
+                        orientations=self.orientation[subset],
                         colors=make_default_colors(len(type_shape['centers'])),
                         points=type_shape['centers'],
                         radii=[0.5 * d for d in type_shape['diameters']],
                     )
                 else:
                     prim = backend.DiskUnions(
-                        position=self.position[subset, :2],
-                        orientation=self.orientation[subset],
+                        positions=self.position[subset, :2],
+                        orientations=self.orientation[subset],
                         colors=make_default_colors(len(type_shape['centers'])),
                         points=[c[:2] for c in type_shape['centers']],
                         radii=[0.5 * d for d in type_shape['diameters']],
                     )
             elif isinstance(type_shape, ConvexPolyhedronShape):
                 prim = backend.ConvexPolyhedra(
-                    position=self.position[subset],
-                    orientation=self.orientation[subset],
+                    positions=self.position[subset],
+                    orientations=self.orientation[subset],
                     colors=make_default_colors(N_prim),
                     vertices=type_shape['vertices'],
                 )
             elif isinstance(type_shape, ConvexSpheropolyhedronShape):
                 prim = backend.ConvexSpheropolyhedra(
-                    position=self.position[subset],
-                    orientation=self.orientation[subset],
+                    positions=self.position[subset],
+                    orientations=self.orientation[subset],
                     colors=make_default_colors(N_prim),
                     vertices=type_shape['vertices'],
                     radius=type_shape['rounding_radius'],
                 )
             elif isinstance(type_shape, GeneralPolyhedronShape):
                 prim = backend.Mesh(
-                    position=self.position[subset],
-                    orientation=self.orientation[subset],
+                    positions=self.position[subset],
+                    orientations=self.orientation[subset],
                     colors=make_default_colors(len(type_shape['vertices'])),
                     vertices=type_shape['vertices'],
                     indices=type_shape['faces'],
@@ -434,15 +434,15 @@ class Frame(object):
                 )
             elif isinstance(type_shape, PolygonShape):
                 prim = backend.Polygons(
-                    position=self.position[subset, :2],
-                    orientation=self.orientation[subset],
+                    positions=self.position[subset, :2],
+                    orientations=self.orientation[subset],
                     colors=make_default_colors(N_prim),
                     vertices=type_shape['vertices'],
                 )
             elif isinstance(type_shape, SpheropolygonShape):
                 prim = backend.Spheropolygons(
-                    position=self.position[subset, :2],
-                    orientation=self.orientation[subset],
+                    positions=self.position[subset, :2],
+                    orientations=self.orientation[subset],
                     colors=make_default_colors(N_prim),
                     vertices=type_shape['vertices'],
                     radius=type_shape['rounding_radius'],

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -219,8 +219,7 @@ class Frame(object):
 
     def _deprecation_warning(self, old_attr, new_attr):
         warnings.warn(
-            "This property was renamed to %s. %s will be removed in version 0.8.0." %
-            (new_attr, old_attr),
+            "This property was renamed to {}. {} will be removed in version 0.8.0.".format(new_attr, old_attr),
             DeprecationWarning
         )
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -313,6 +313,17 @@ class Frame(object):
             raise ValueError("Input array must be of shape (N,{}) where N is the number of particles.".format(size))
         return value
 
+    def _validate_input_scalar(self, value):
+        try:
+            value = np.asarray(value, dtype=self._dtype)
+        except ValueError:
+            raise ValueError("This property can only be set to numeric arrays.")
+        if not np.all(np.isfinite(value)):
+            raise ValueError("Property being set must all be finite numbers.")
+        elif not len(value.shape) == 1:
+            raise ValueError("Input array must be of shape (N) where N is the number of particles.")
+        return value
+
     def loaded(self):
         "Returns True if the frame is loaded into memory."
         return self.frame_data is not None
@@ -605,14 +616,7 @@ class Frame(object):
 
     @mass.setter
     def mass(self, value):
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("Masses can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("Masses being set must all be finite numbers.")
-        elif not len(value.shape) == 1:
-            raise ValueError("Input array must be of shape (N) where N is the number of particles.")
+        self._validate_input_scalar(value)
         self.load()
         self.frame_data.mass = value
 
@@ -624,14 +628,7 @@ class Frame(object):
 
     @charge.setter
     def charge(self, value):
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("Charges can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("Charges being set must all be finite numbers.")
-        elif not len(value.shape) == 1:
-            raise ValueError("Input array must be of shape (N) where N is the number of particles.")
+        self._validate_input_scalar(value)
         self.load()
         self.frame_data.charge = value
 
@@ -643,14 +640,7 @@ class Frame(object):
 
     @diameter.setter
     def diameter(self, value):
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("Diameters can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("Diameters being set must all be finite numbers.")
-        elif not len(value.shape) == 1:
-            raise ValueError("Input array must be of shape (N) where N is the number of particles.")
+        self._validate_input_scalar(value)
         self.load()
         self.frame_data.diameter = value
 
@@ -663,14 +653,7 @@ class Frame(object):
     @moment_inertia.setter
     def moment_inertia(self, value):
         ndof = self.box.dimensions * (self.box.dimensions - 1) / 2
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("Moments of inertia can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("Moments of inertia being set must all be finite numbers.")
-        elif not len(value.shape) == 2 or value.shape[1] != ndof:
-            raise ValueError("Input array must be of shape (N,{}) where N is the number of particles.".format(ndof))
+        self._validate_input_array(value, ndof)
         self.load()
         self.frame_data.moment_inertia = value
 
@@ -682,15 +665,7 @@ class Frame(object):
 
     @angmom.setter
     def angmom(self, value):
-        try:
-            value = np.asarray(value, dtype=self._dtype)
-        except ValueError:
-            raise ValueError("Angular momenta can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("Angular momenta being set must all be finite numbers.")
-        elif not len(value.shape) == 2 or value.shape[1] != 4:
-            raise ValueError("Input array must be of shape (N,4) where N is the number of particles.")
-
+        self._validate_input_array(value, 4)
         self.load()
         self.frame_data.angmom = value
 
@@ -702,14 +677,7 @@ class Frame(object):
 
     @image.setter
     def image(self, value):
-        try:
-            value = np.asarray(value, dtype=np.int32)
-        except ValueError:
-            raise ValueError("Images can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
-            raise ValueError("Images being set must all be finite numbers.")
-        elif not len(value.shape) == 2 or value.shape[1] != 3:
-            raise ValueError("Input array must be of shape (N,3) where N is the number of particles.")
+        self._validate_input_array(value, 3)
         self.load()
         self.frame_data.image = value
 

--- a/tests/test_ciffilereaderwriter.py
+++ b/tests/test_ciffilereaderwriter.py
@@ -48,28 +48,28 @@ class CifFileWriterTest(BaseCifFileWriterTest):
         traj = self.read_pos_trajectory(sample)
         dump = io.StringIO()
         self.write_trajectory(traj, dump)
-        return (traj[-1].positions, dump)
+        return (traj[-1].position, dump)
 
     def test_incsim_dialect(self):
         sample = io.StringIO(garnett.samples.POS_INCSIM)
         traj = self.read_pos_trajectory(sample)
         dump = io.StringIO()
         self.write_trajectory(traj, dump)
-        return (traj[-1].positions, dump)
+        return (traj[-1].position, dump)
 
     def test_monotype_dialect(self):
         sample = io.StringIO(garnett.samples.POS_MONOTYPE)
         traj = self.read_pos_trajectory(sample)
         dump = io.StringIO()
         self.write_trajectory(traj, dump)
-        return (traj[-1].positions, dump)
+        return (traj[-1].position, dump)
 
     def test_injavis_dialect(self):
         sample = io.StringIO(garnett.samples.POS_INJAVIS)
         traj = self.read_pos_trajectory(sample)
         dump = io.StringIO()
         self.write_trajectory(traj, dump)
-        return (traj[-1].positions, dump)
+        return (traj[-1].position, dump)
 
 
 class CifFileReaderTest(CifFileWriterTest):
@@ -78,62 +78,62 @@ class CifFileReaderTest(CifFileWriterTest):
     # fail because particles in the pos file examples lie outside the box
 
     def test_hpmc_dialect(self):
-        (ref_positions, sample) = super(CifFileReaderTest, self).test_hpmc_dialect()
+        (ref_position, sample) = super(CifFileReaderTest, self).test_hpmc_dialect()
         sample = io.StringIO(sample.getvalue())
         traj = self.read_cif_trajectory(sample)
-        logger.debug('Cif-read positions:')
-        logger.debug(traj[-1].positions)
-        logger.debug('Pos-read positions:')
-        logger.debug(ref_positions)
-        self.assertTrue(np.allclose(traj[-1].positions, ref_positions))
+        logger.debug('Cif-read position:')
+        logger.debug(traj[-1].position)
+        logger.debug('Pos-read position:')
+        logger.debug(ref_position)
+        self.assertTrue(np.allclose(traj[-1].position, ref_position))
 
     def test_incsim_dialect(self):
-        (ref_positions, sample) = super(CifFileReaderTest, self).test_incsim_dialect()
+        (ref_position, sample) = super(CifFileReaderTest, self).test_incsim_dialect()
         sample = io.StringIO(sample.getvalue())
         traj = self.read_cif_trajectory(sample)
-        logger.debug('Cif-read positions:')
-        logger.debug(traj[-1].positions)
-        logger.debug('Pos-read positions:')
-        logger.debug(ref_positions)
-        self.assertTrue(np.allclose(traj[-1].positions, ref_positions))
+        logger.debug('Cif-read position:')
+        logger.debug(traj[-1].position)
+        logger.debug('Pos-read position:')
+        logger.debug(ref_position)
+        self.assertTrue(np.allclose(traj[-1].position, ref_position))
 
     def test_monotype_dialect(self):
-        (ref_positions, sample) = super(CifFileReaderTest, self).test_monotype_dialect()
+        (ref_position, sample) = super(CifFileReaderTest, self).test_monotype_dialect()
         sample = io.StringIO(sample.getvalue())
         traj = self.read_cif_trajectory(sample)
-        logger.debug('Cif-read positions:')
-        logger.debug(traj[-1].positions)
-        logger.debug('Pos-read positions:')
-        logger.debug(ref_positions)
-        self.assertTrue(np.allclose(traj[-1].positions, ref_positions))
+        logger.debug('Cif-read position:')
+        logger.debug(traj[-1].position)
+        logger.debug('Pos-read position:')
+        logger.debug(ref_position)
+        self.assertTrue(np.allclose(traj[-1].position, ref_position))
 
     def test_injavis_dialect(self):
-        (ref_positions, sample) = super(CifFileReaderTest, self).test_injavis_dialect()
+        (ref_position, sample) = super(CifFileReaderTest, self).test_injavis_dialect()
         sample = io.StringIO(sample.getvalue())
         traj = self.read_cif_trajectory(sample)
-        logger.debug('Cif-read positions:')
-        logger.debug(traj[-1].positions)
-        logger.debug('Pos-read positions:')
-        logger.debug(ref_positions)
-        self.assertTrue(np.allclose(traj[-1].positions, ref_positions))
+        logger.debug('Cif-read position:')
+        logger.debug(traj[-1].position)
+        logger.debug('Pos-read position:')
+        logger.debug(ref_position)
+        self.assertTrue(np.allclose(traj[-1].position, ref_position))
 
     def test_cif_read_write(self):
         sample = io.StringIO(garnett.samples.CIF)
         traj = self.read_cif_trajectory(sample)
-        ref_positions = traj[-1].positions
+        ref_position = traj[-1].position
         dump = io.StringIO()
         self.write_trajectory(traj, dump)
         sample = io.StringIO(dump.getvalue())
         traj = self.read_cif_trajectory(sample)
-        logger.debug('Cif-read positions:')
-        logger.debug(traj[-1].positions)
-        logger.debug('original positions:')
-        logger.debug(ref_positions)
+        logger.debug('Cif-read position:')
+        logger.debug(traj[-1].position)
+        logger.debug('original position:')
+        logger.debug(ref_position)
         cif_coordinates = np.array(
                 [[0.333333333, 0.6666666667, 0.25],
                  [0.6666666667, 0.333333333, 0.75]])
 
-        self.assertTrue(np.allclose(traj[-1].positions, ref_positions))
+        self.assertTrue(np.allclose(traj[-1].position, ref_position))
         self.assertTrue(np.allclose(traj[-1].cif_coordinates, cif_coordinates))
 
         with self.assertRaises(ValueError):

--- a/tests/test_dcdfilereader.py
+++ b/tests/test_dcdfilereader.py
@@ -51,7 +51,7 @@ class BaseDCDFileReaderTest(TrajectoryTest):
         with self.assertRaises(AttributeError):
             frame.mass
         with self.assertRaises(AttributeError):
-            frame.velocities
+            frame.velocity
         with self.assertRaises(AttributeError):
             frame.shapedef
 
@@ -67,7 +67,7 @@ class BaseDCDFileReaderTest(TrajectoryTest):
                 [4.713492870331, 0, 0],
                 [0, 4.713492870331, 0],
                 [0, 0, 4.713492870331]])))
-        self.assertTrue(np.allclose(traj[-1].positions, np.array([
+        self.assertTrue(np.allclose(traj[-1].position, np.array([
             [1.0384979248, 2.34347701073, -0.391116261482],
             [-1.75283277035, -2.35620737076, 2.03885579109],
             [-1.66501355171, 2.35222411156, -0.931703925133],

--- a/tests/test_getarfilereader.py
+++ b/tests/test_getarfilereader.py
@@ -25,9 +25,9 @@ class BaseGetarFileReaderTest(unittest.TestCase):
         self.getar_file_fn = os.path.join(self.tmp_dir.name, 'sample.tar')
 
     def setup_sample(self, N, dim=3):
-        self.positions = np.random.rand(N, 3)
-        self.orientations = np.random.rand(N, 4)
-        self.velocities = np.random.rand(N, 3)
+        self.position = np.random.rand(N, 3)
+        self.orientation = np.random.rand(N, 4)
+        self.velocity = np.random.rand(N, 3)
         self.mass = np.random.rand(N)
         self.charge = np.random.rand(N)
         self.diameter = np.random.rand(N)
@@ -39,13 +39,13 @@ class BaseGetarFileReaderTest(unittest.TestCase):
         self.box = np.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
         self.types = [type_names[t] for t in types]
         if dim == 2:
-            self.positions[:, 2] = 0
-            self.velocities[:, 2] = 0
+            self.position[:, 2] = 0
+            self.velocity[:, 2] = 0
 
         with gtar.GTAR(self.getar_file_fn, 'w') as traj:
-            traj.writePath('frames/0/position.f32.ind', self.positions)
-            traj.writePath('frames/0/orientation.f32.ind', self.orientations)
-            traj.writePath('frames/0/velocity.f32.ind', self.velocities)
+            traj.writePath('frames/0/position.f32.ind', self.position)
+            traj.writePath('frames/0/orientation.f32.ind', self.orientation)
+            traj.writePath('frames/0/velocity.f32.ind', self.velocity)
             traj.writePath('frames/0/mass.f32.ind', self.mass)
             traj.writePath('frames/0/charge.f32.ind', self.charge)
             traj.writePath('frames/0/diameter.f32.ind', self.diameter)
@@ -71,9 +71,9 @@ class BaseGetarFileReaderTest(unittest.TestCase):
         self.assertEqual(len(frame), N)
         self.assertEqual(frame.box, garnett.trajectory.Box(1.0, 1.0, 1.0))
         self.assertEqual(frame.box.dimensions, 3)
-        np.testing.assert_allclose(frame.positions, self.positions)
-        np.testing.assert_allclose(frame.orientations, self.orientations)
-        np.testing.assert_allclose(frame.velocities, self.velocities)
+        np.testing.assert_allclose(frame.position, self.position)
+        np.testing.assert_allclose(frame.orientation, self.orientation)
+        np.testing.assert_allclose(frame.velocity, self.velocity)
         np.testing.assert_allclose(frame.mass, self.mass)
         np.testing.assert_allclose(frame.charge, self.charge)
         np.testing.assert_allclose(frame.diameter, self.diameter)
@@ -91,9 +91,9 @@ class BaseGetarFileReaderTest(unittest.TestCase):
         self.assertEqual(len(frame), N)
         self.assertEqual(frame.box, garnett.trajectory.Box(1.0, 1.0, 1.0, dimensions=2))
         self.assertEqual(frame.box.dimensions, 2)
-        np.testing.assert_allclose(frame.positions, self.positions)
-        np.testing.assert_allclose(frame.orientations, self.orientations)
-        np.testing.assert_allclose(frame.velocities, self.velocities)
+        np.testing.assert_allclose(frame.position, self.position)
+        np.testing.assert_allclose(frame.orientation, self.orientation)
+        np.testing.assert_allclose(frame.velocity, self.velocity)
         np.testing.assert_allclose(frame.mass, self.mass)
         np.testing.assert_allclose(frame.charge, self.charge)
         np.testing.assert_allclose(frame.diameter, self.diameter)
@@ -110,9 +110,9 @@ class NoTypesGetarFileReaderTest(BaseGetarFileReaderTest):
     types."""
 
     def setup_sample(self, N, dim=3):
-        self.positions = np.random.rand(N, 3)
-        self.orientations = np.random.rand(N, 4)
-        self.velocities = np.random.rand(N, 3)
+        self.position = np.random.rand(N, 3)
+        self.orientation = np.random.rand(N, 4)
+        self.velocity = np.random.rand(N, 3)
         self.mass = np.random.rand(N)
         self.charge = np.random.rand(N)
         self.diameter = np.random.rand(N)
@@ -122,13 +122,13 @@ class NoTypesGetarFileReaderTest(BaseGetarFileReaderTest):
         self.box = np.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
         self.types = N*['A']
         if dim == 2:
-            self.positions[:, 2] = 0
-            self.velocities[:, 2] = 0
+            self.position[:, 2] = 0
+            self.velocity[:, 2] = 0
 
         with gtar.GTAR(self.getar_file_fn, 'w') as traj:
-            traj.writePath('frames/0/position.f32.ind', self.positions)
-            traj.writePath('frames/0/orientation.f32.ind', self.orientations)
-            traj.writePath('frames/0/velocity.f32.ind', self.velocities)
+            traj.writePath('frames/0/position.f32.ind', self.position)
+            traj.writePath('frames/0/orientation.f32.ind', self.orientation)
+            traj.writePath('frames/0/velocity.f32.ind', self.velocity)
             traj.writePath('frames/0/mass.f32.ind', self.mass)
             traj.writePath('frames/0/charge.f32.ind', self.charge)
             traj.writePath('frames/0/diameter.f32.ind', self.diameter)

--- a/tests/test_getarfilewriter.py
+++ b/tests/test_getarfilewriter.py
@@ -35,7 +35,7 @@ class BaseGetarFileWriterTest(unittest.TestCase):
         traj.load_arrays()
         len_orig = len(traj)
         readwrite_props = ['N', 'types', 'type_ids',
-                           'positions', 'orientations', 'velocities',
+                           'position', 'orientation', 'velocity',
                            'mass', 'charge', 'diameter',
                            'moment_inertia', 'angmom', 'image']
         original_data = {}

--- a/tests/test_gsdhoomdfilereader.py
+++ b/tests/test_gsdhoomdfilereader.py
@@ -83,7 +83,7 @@ class BaseGSDHOOMDFileReaderTest(TrajectoryTest):
         self.assertTrue(np.allclose(
             np.asarray(traj[0].box.get_box_matrix()),
             np.array([[8.0, 0, 0], [0, 10.0, 0], [0, 0, 10.0]])))
-        self.assertTrue(np.allclose(traj[0].positions, np.array([
+        self.assertTrue(np.allclose(traj[0].position, np.array([
          [-3., -4., -4.],
          [-3., -4., -2.],
          [-3., -4.,  0.],
@@ -414,9 +414,9 @@ class BaseGSDHOOMDFileReaderTest(TrajectoryTest):
                                     dynamic=['attribute', 'property', 'momentum'])
         gsd_writer.dump_state(self.mc)
         prop_map = dict(
-            position='positions',
-            orientation='orientations',
-            velocity='velocities',
+            position='position',
+            orientation='orientation',
+            velocity='velocity',
             angular_momentum='angmom')
         with open(self.fn_gsd, 'rb') as gsdfile:
             gsd_reader = garnett.gsdhoomdfilereader.GSDHOOMDFileReader()

--- a/tests/test_gsdhoomdfilewriter.py
+++ b/tests/test_gsdhoomdfilewriter.py
@@ -67,7 +67,7 @@ class BaseGSDHOOMDFileWriterTest(unittest.TestCase):
         traj.load_arrays()
         len_orig = len(traj)
         readwrite_props = ['N', 'types', 'type_ids',
-                           'positions', 'orientations', 'velocities',
+                           'position', 'orientation', 'velocity',
                            'mass', 'charge', 'diameter',
                            'moment_inertia', 'angmom', 'image']
         original_data = {}
@@ -116,7 +116,7 @@ class BaseGSDHOOMDFileWriterTest(unittest.TestCase):
                 self.writer.write(traj, tmpfile)
                 written_traj = self.reader.read(tmpfile)
                 assert np.array_equal(written_traj[0].mass, np.ones(27).astype(float))
-                assert np.array_equal(written_traj[0].velocities, np.zeros([27, 3]).astype(float))
+                assert np.array_equal(written_traj[0].velocity, np.zeros([27, 3]).astype(float))
                 assert np.array_equal(written_traj[0].diameter, np.ones(27).astype(float))
                 assert np.array_equal(written_traj[0].moment_inertia, np.zeros([27, 3]).astype(float))
                 assert np.array_equal(written_traj[0].angmom, np.zeros([27, 4]).astype(float))

--- a/tests/test_hoomdxmlreader.py
+++ b/tests/test_hoomdxmlreader.py
@@ -18,7 +18,7 @@ class BaseHOOMDXMLFileReaderTest(unittest.TestCase):
         traj = self.read_trajectory(garnett.samples.HOOMD_BLUE_XML)
         self.assertEqual(len(traj), 1)
         self.assertEqual(len(traj[0]), 10)
-        self.assertTrue(np.allclose(traj[0].positions, np.array([
+        self.assertTrue(np.allclose(traj[0].position, np.array([
             [-0.391116261482, 2.34347701073, 1.0384979248],
             [2.03885579109, -2.35620737076, -1.75283277035],
             [-0.931703925133, 2.35222411156, -1.66501355171],
@@ -30,7 +30,7 @@ class BaseHOOMDXMLFileReaderTest(unittest.TestCase):
             [-1.39306223392, -0.266534328461, 1.78225398064],
             [-1.27463591099, -2.22765517235, 0.162209749222],
         ])))
-        self.assertTrue(np.allclose(traj[0].velocities, np.array([
+        self.assertTrue(np.allclose(traj[0].velocity, np.array([
             [-0.391116261482, 2.34347701073, 1.0384979248],
             [2.03885579109, -2.35620737076, -1.75283277035],
             [-0.931703925133, 2.35222411156, -1.66501355171],
@@ -55,7 +55,7 @@ class BaseHOOMDXMLFileReaderTest(unittest.TestCase):
         traj = self.read_trajectory(garnett.samples.HOOMD_BLUE_XML_2D)
         self.assertEqual(len(traj), 1)
         self.assertEqual(len(traj[0]), 10)
-        self.assertTrue(np.allclose(traj[0].positions, np.array([
+        self.assertTrue(np.allclose(traj[0].position, np.array([
                [-0.391116261482, 2.34347701073, 0],
                [2.03885579109, -2.35620737076, 0],
                [-0.931703925133, 2.35222411156, 0],
@@ -67,7 +67,7 @@ class BaseHOOMDXMLFileReaderTest(unittest.TestCase):
                [-1.39306223392, -0.266534328461, 0],
                [-1.27463591099, -2.22765517235, 0],
            ])))
-        self.assertTrue(np.allclose(traj[0].velocities, np.array([
+        self.assertTrue(np.allclose(traj[0].velocity, np.array([
                [-0.391116261482, 2.34347701073, 0],
                [2.03885579109, -2.35620737076, 0],
                [-0.931703925133, 2.35222411156, 0],

--- a/tests/test_posfilereaderwriter.py
+++ b/tests/test_posfilereaderwriter.py
@@ -164,7 +164,7 @@ class PosFileReaderTest(BasePosFileReaderTest):
         self.assert_raise_attribute_error(traj)
 
     def test_default(self):
-        with TemporaryDirectory() as _:
+        with TemporaryDirectory() as tmp_dir:
             gsdfile = 'testfile.gsd'
             posfile = 'testfile.pos'
             with open(gsdfile, "wb") as f:
@@ -176,9 +176,8 @@ class PosFileReaderTest(BasePosFileReaderTest):
             with garnett.read(posfile) as traj:
                 for frame in traj:
                     for name in frame.shapedef.keys():
-                        self.assertEqual(frame.shapedef[name],
+                        self.assertEqual(frame.shapedef[name], \
                                          DEFAULT_SHAPE_DEFINITION)
-
 
 @unittest.skipIf(not HPMC, 'requires HPMC')
 class HPMCPosFileReaderTest(BasePosFileReaderTest):

--- a/tests/test_posfilereaderwriter.py
+++ b/tests/test_posfilereaderwriter.py
@@ -164,7 +164,7 @@ class PosFileReaderTest(BasePosFileReaderTest):
         self.assert_raise_attribute_error(traj)
 
     def test_default(self):
-        with TemporaryDirectory() as tmp_dir:
+        with TemporaryDirectory() as _:
             gsdfile = 'testfile.gsd'
             posfile = 'testfile.pos'
             with open(gsdfile, "wb") as f:
@@ -176,8 +176,9 @@ class PosFileReaderTest(BasePosFileReaderTest):
             with garnett.read(posfile) as traj:
                 for frame in traj:
                     for name in frame.shapedef.keys():
-                        self.assertEqual(frame.shapedef[name], \
+                        self.assertEqual(frame.shapedef[name],
                                          DEFAULT_SHAPE_DEFINITION)
+
 
 @unittest.skipIf(not HPMC, 'requires HPMC')
 class HPMCPosFileReaderTest(BasePosFileReaderTest):

--- a/tests/test_posfilereaderwriter.py
+++ b/tests/test_posfilereaderwriter.py
@@ -56,7 +56,7 @@ class BasePosFileReaderTest(unittest.TestCase):
 
     def assert_raise_attribute_error(self, frame):
         with self.assertRaises(AttributeError):
-            frame.velocities
+            frame.velocity
         with self.assertRaises(AttributeError):
             frame.charge
         with self.assertRaises(AttributeError):
@@ -81,17 +81,17 @@ class BasePosFileWriterTest(BasePosFileReaderTest):
 
     def assert_approximately_equal_frames(self, a, b,
                                           decimals=6, atol=1e-5,
-                                          ignore_orientations=False):
+                                          ignore_orientation=False):
         self.assertEqual(a.box.round(decimals), b.box.round(decimals))
         self.assertEqual(a.types, b.types)
-        self.assertTrue(np.allclose(a.positions, b.positions, atol=atol))
+        self.assertTrue(np.allclose(a.position, b.position, atol=atol))
         try:
-            self.assertTrue(np.allclose(a.velocities, b.velocities, atol=atol))
+            self.assertTrue(np.allclose(a.velocity, b.velocity, atol=atol))
         except AttributeError:
             pass
-        if not ignore_orientations:
+        if not ignore_orientation:
             try:
-                self.assertTrue(np.allclose(a.orientations, b.orientations, atol=atol))
+                self.assertTrue(np.allclose(a.orientation, b.orientation, atol=atol))
             except AttributeError:
                 pass
         self.assertEqual(a.data, b.data)
@@ -349,7 +349,7 @@ class PosFileWriterTest(BasePosFileWriterTest):
         traj.load_arrays()
         for frame in traj:
             frame.shapedef['A'] = ArrowShape()
-            frame.orientations.T[3] = 0
+            frame.orientation.T[3] = 0
         dump = io.StringIO()
         self.write_trajectory(traj, dump)
         dump.seek(0)
@@ -430,7 +430,7 @@ class PosFileWriterTest(BasePosFileWriterTest):
                     for f0, f1 in zip(traj0, traj1):
                         self.assert_approximately_equal_frames(
                             f0, f1, decimals=4, atol=1e-6,
-                            ignore_orientations=True  # The shapes themselves are differently oriented
+                            ignore_orientation=True  # The shapes themselves are differently oriented
                             )
 
 

--- a/tests/test_pydcdfilereader.py
+++ b/tests/test_pydcdfilereader.py
@@ -46,7 +46,7 @@ class BaseDCDFileReaderTest(TrajectoryTest):
         with self.assertRaises(AttributeError):
             frame.mass
         with self.assertRaises(AttributeError):
-            frame.velocities
+            frame.velocity
         with self.assertRaises(AttributeError):
             frame.shapedef
 
@@ -60,7 +60,7 @@ class BaseDCDFileReaderTest(TrajectoryTest):
                 [4.713492870331, 0, 0],
                 [0, 4.713492870331, 0],
                 [0, 0, 4.713492870331]])))
-        self.assertTrue(np.allclose(traj[-1].positions, np.array([
+        self.assertTrue(np.allclose(traj[-1].position, np.array([
             [1.0384979248, 2.34347701073, -0.391116261482],
             [-1.75283277035, -2.35620737076, 2.03885579109],
             [-1.66501355171, 2.35222411156, -0.931703925133],

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -70,7 +70,6 @@ class ShapeTest(unittest.TestCase):
                 npt.assert_almost_equal(getattr(shape_A, key), value)
                 npt.assert_almost_equal(type_shape[key], value)
 
-
 @ddt
 class GSDShapeTest(ShapeTest):
     reader = garnett.reader.GSDHOOMDFileReader

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -70,6 +70,7 @@ class ShapeTest(unittest.TestCase):
                 npt.assert_almost_equal(getattr(shape_A, key), value)
                 npt.assert_almost_equal(type_shape[key], value)
 
+
 @ddt
 class GSDShapeTest(ShapeTest):
     reader = garnett.reader.GSDHOOMDFileReader

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -175,6 +175,8 @@ class TrajectoryTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 # This should fail since it's using 2d positions
                 traj[0].position = [[0, 0], [0, 0]]
+            with self.assertWarns(DeprecationWarning):
+                self.assertTrue(np.array_equal(traj[0].positions, traj[0].position))
 
     def test_orientation(self):
         sample_file = self.get_sample_file()
@@ -194,6 +196,8 @@ class TrajectoryTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 # This should fail since it's using 2d positions
                 traj[0].orientation = [[0, 0], [0, 0]]
+            with self.assertWarns(DeprecationWarning):
+                self.assertTrue(np.array_equal(traj[0].orientations, traj[0].orientation))
         except AttributeError:
             pass
 
@@ -215,6 +219,8 @@ class TrajectoryTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 # This should fail since it's using 2d velocities
                 traj[0].velocity = [[0, 0], [0, 0]]
+            with self.assertWarns(DeprecationWarning):
+                self.assertTrue(np.array_equal(traj[0].velocities, traj[0].velocity))
         except AttributeError:
             pass
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -99,20 +99,20 @@ class TrajectoryTest(unittest.TestCase):
         sample_file = self.get_sample_file()
         traj = self.reader().read(sample_file)
         for frame in traj:
-            self.assertTrue(isinstance(frame.positions, np.ndarray))
-            self.assertTrue(frame.positions.dtype ==
+            self.assertTrue(isinstance(frame.position, np.ndarray))
+            self.assertTrue(frame.position.dtype ==
                             garnett.trajectory.DEFAULT_DTYPE)
         for dtype in (np.float32, np.float64):
             traj.set_dtype(dtype)
             for frame in traj:
-                self.assertTrue(isinstance(frame.positions, np.ndarray))
-                self.assertTrue(frame.positions.dtype == dtype)
+                self.assertTrue(isinstance(frame.position, np.ndarray))
+                self.assertTrue(frame.position.dtype == dtype)
         traj.set_dtype(np.float32)
         frame0 = traj[0]
-        self.assertTrue(frame0.positions.dtype == np.float32)
+        self.assertTrue(frame0.position.dtype == np.float32)
         frame0.load()
-        self.assertTrue(isinstance(frame0.positions, np.ndarray))
-        self.assertTrue(frame0.positions.dtype == np.float32)
+        self.assertTrue(isinstance(frame0.position, np.ndarray))
+        self.assertTrue(frame0.position.dtype == np.float32)
         with self.assertRaises(RuntimeError):
             traj.set_dtype(np.float64)
         with self.assertRaises(RuntimeError):
@@ -159,62 +159,62 @@ class TrajectoryTest(unittest.TestCase):
         type_ids_0 = [traj.type.index(t) for t in traj.types[0]]
         self.assertEqual(type_ids_0, traj.type_ids[0].tolist())
 
-    def test_positions(self):
+    def test_position(self):
         sample_file = self.get_sample_file()
         traj = self.reader().read(sample_file)
         with self.assertRaises(RuntimeError):
-            traj.positions
+            traj.position
         traj.load_arrays()
-        if traj.positions is not None and None not in traj.positions:
+        if traj.position is not None and None not in traj.position:
             self.assertTrue(np.issubdtype(
-                traj.positions.dtype, garnett.trajectory.DEFAULT_DTYPE))
-            self.assertEqual(traj.positions.shape, (len(traj), len(traj[0]), 3))
-            self.assertTrue((traj.positions[0] == traj[0].positions).all())
+                traj.position.dtype, garnett.trajectory.DEFAULT_DTYPE))
+            self.assertEqual(traj.position.shape, (len(traj), len(traj[0]), 3))
+            self.assertTrue((traj.position[0] == traj[0].position).all())
             with self.assertRaises(ValueError):
-                traj[0].positions = 'hello'
+                traj[0].position = 'hello'
             with self.assertRaises(ValueError):
                 # This should fail since it's using 2d positions
-                traj[0].positions = [[0, 0], [0, 0]]
+                traj[0].position = [[0, 0], [0, 0]]
 
-    def test_orientations(self):
+    def test_orientation(self):
         sample_file = self.get_sample_file()
         traj = self.reader().read(sample_file)
         with self.assertRaises(RuntimeError):
-            traj.orientations
+            traj.orientation
         traj.load_arrays()
         try:
-            if len(traj.orientations.shape) > 1:
+            if len(traj.orientation.shape) > 1:
                 self.assertTrue(np.issubdtype(
-                    traj.orientations.dtype, garnett.trajectory.DEFAULT_DTYPE))
-                self.assertEqual(traj.orientations.shape,
+                    traj.orientation.dtype, garnett.trajectory.DEFAULT_DTYPE))
+                self.assertEqual(traj.orientation.shape,
                                  (len(traj), len(traj[0]), 4))
-                self.assertTrue((traj.orientations[0] == traj[0].orientations).all())
+                self.assertTrue((traj.orientation[0] == traj[0].orientation).all())
             with self.assertRaises(ValueError):
-                traj[0].orientations = 'hello'
+                traj[0].orientation = 'hello'
             with self.assertRaises(ValueError):
                 # This should fail since it's using 2d positions
-                traj[0].orientations = [[0, 0], [0, 0]]
+                traj[0].orientation = [[0, 0], [0, 0]]
         except AttributeError:
             pass
 
-    def test_velocities(self):
+    def test_velocity(self):
         sample_file = self.get_sample_file()
         traj = self.reader().read(sample_file)
         with self.assertRaises(RuntimeError):
-            traj.velocities
+            traj.velocity
         traj.load_arrays()
         try:
-            if len(traj.velocities.shape) > 1:
+            if len(traj.velocity.shape) > 1:
                 self.assertTrue(np.issubdtype(
-                    traj.velocities.dtype, garnett.trajectory.DEFAULT_DTYPE))
-                self.assertEqual(traj.velocities.shape,
+                    traj.velocity.dtype, garnett.trajectory.DEFAULT_DTYPE))
+                self.assertEqual(traj.velocity.shape,
                                  (len(traj), len(traj[0]), 3))
-                self.assertTrue((traj.velocities[0] == traj[0].velocities).all())
+                self.assertTrue((traj.velocity[0] == traj[0].velocity).all())
             with self.assertRaises(ValueError):
-                traj[0].velocities = 'hello'
+                traj[0].velocity = 'hello'
             with self.assertRaises(ValueError):
                 # This should fail since it's using 2d velocities
-                traj[0].velocities = [[0, 0], [0, 0]]
+                traj[0].velocity = [[0, 0], [0, 0]]
         except AttributeError:
             pass
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
1. Change traj.positions and frame.positions to traj.position and frame.position
2. Change traj.orientations and frame.orientations to traj.orientation and frame.orientation
3. Change traj.velocities and frame.velocities to traj.velocity and frame.velocity
4. Keep the original positions, orientations, velocities and raise deprecation warning 
TO DO LIST:
1. Change warning levels so that they print on the screen. Maybe use package deprecation will resolve this better.
2. Finish updating documentation
3. Resolve issues with type, types, type_ids
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #76 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
Perform unit tests on the updated property names. Make sure the old names return the same value as the updated one. Check that the warning is actually raised.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [?] I have updated the documentation (if relevant).
- [?] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
