### PR TITLE
Enable templates for DCD files in garnett.read.

### DIFF
--- a/garnett/util.py
+++ b/garnett/util.py
@@ -105,7 +105,7 @@ def read(filename_or_fileobj, template=None, fmt=None):
         if template is None:
             traj = file_reader.read(read_file)
             yield traj
-        elif file_format == 'gsd':
+        elif file_format in ['gsd', 'dcd']:
             file_reader = READ_CLASS_MODES[file_format]['reader']()
             with read(template) as templatetraj:
                 traj = file_reader.read(read_file, templatetraj[0])


### PR DESCRIPTION
## Description
To enable the "orientation hack" for DCD files, where the z-component is treated as an orientation, the DCD file reader class requires a template frame with a 2D box. A similar feature has been enabled for GSD files where the template frame provides shape information, so I turned this on for DCD files.

To use this feature, an auxiliary "template" file is needed. In my understanding, DCD files are usually dumped alongside some other kind of file/frame (e.g. GSD). If that's correct, enabling the orientation z-hack should look something like (untested):

```python
with garnett.read('dump.dcd', template='dump.gsd') as traj:
    print(traj[0].box)
    print(traj[0].orientations)
```

## Motivation and Context
Resolves: #135.

## How Has This Been Tested?
@shannon-moran will test this. Ideally we can add a couple of files to test with long-term.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
