### PR TITLE
Add another source of cif file space group symmetry operations

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,16 @@ Changelog
 
 The **garnett** package follows `semantic versioning <https://semver.org/>`_.
 
+Version 0.7
+===========
+
+[0.7.0]
+-------
+
+Added
++++++
+  - Added ability to read ``_space_group_symop_operation_xyz`` keys in CIF files.
+
 Version 0.6
 ===========
 

--- a/garnett/ciffilereader.py
+++ b/garnett/ciffilereader.py
@@ -140,10 +140,13 @@ class CifFileFrame(Frame):
         else:
             site_types = len(fractions)*[self.default_type]
 
-        if '_symmetry_equiv_pos_as_xyz' in self.parsed:
+        space_group_keys = ['_symmetry_equiv_pos_as_xyz', '_space_group_symop_operation_xyz']
+        found_keys = [key for key in space_group_keys if key in self.parsed]
+        if found_keys:
+            key_to_use = found_keys[0]
             symmetry_ops = [PARSE_DIVISION_REGEXP.sub(
                             _parse_division, REMOVE_NONNUM_REGEXP.sub('', sym))
-                            for sym in self.parsed['_symmetry_equiv_pos_as_xyz']]
+                            for sym in self.parsed[key_to_use]]
 
             replicated_fractions = []
             replicated_types = []

--- a/tests/test_ciffilereaderwriter.py
+++ b/tests/test_ciffilereaderwriter.py
@@ -117,6 +117,26 @@ class CifFileReaderTest(CifFileWriterTest):
         logger.debug(ref_positions)
         self.assertTrue(np.allclose(traj[-1].positions, ref_positions))
 
+    def test_aflow_dialect(self):
+        sample = io.StringIO(garnett.samples.CIF)
+        traj = self.read_cif_trajectory(sample)
+
+        aflow_dialect_cif = garnett.samples.CIF.replace(
+            '_symmetry_equiv_pos_as_xyz',
+            '_space_group_symop_operation_xyz')
+        aflow_sample = io.StringIO(aflow_dialect_cif)
+        aflow_traj = self.read_cif_trajectory(aflow_sample)
+
+        logger.debug('AFLOW cif-read positions:')
+        logger.debug(aflow_traj[-1].positions)
+        logger.debug('Cif-read positions:')
+        logger.debug(traj[-1].positions)
+
+        # confirm that the string was modified
+        self.assertNotEqual(garnett.samples.CIF, aflow_dialect_cif)
+        # confirm that positions are the same
+        self.assertTrue(np.allclose(aflow_traj[-1].positions, traj[-1].positions))
+
     def test_cif_read_write(self):
         sample = io.StringIO(garnett.samples.CIF)
         traj = self.read_cif_trajectory(sample)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This PR makes the CIF reader check both the `_symmetry_equiv_pos_as_xyz` and `_space_group_symop_operation_xyz` keys. The latter is a different name for the same data, used in CIF files found in the [AFLOW Library of Crystallographic Prototypes](http://aflowlib.org/CrystalDatabase/index.html)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Needed to read cif files from the AFLOW database listed above.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
The change is minor, but has been tested on cif files from the AFLOW database.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
