### PR TITLE
Use types and typeid properties consistent with HOOMD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: style-check
           command: |
             pip install --user -U flake8==3.7.1
-            python -m flake8 --show-source garnett/
+            python -m flake8 --show-source .
 
 
   test-3.7: &test-template

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ sub_trajectory = traj[i:j]
 Access properties of trajectories:
 ```python
 traj.load_arrays()
+traj.N               # M
+traj.types           # MxT
+traj.type_shapes     # MxT
+traj.typeid          # MxN
 traj.position        # MxNx3
 traj.orientation     # MxNx4
 traj.velocity        # MxNx3
@@ -77,19 +81,21 @@ traj.charge          # MxN
 traj.diameter        # MxN
 traj.moment_inertia  # MxNx3
 traj.angmom          # MxNx4
-traj.types           # MxT
+traj.image           # MxNx3
 
-# M is the number of frames: len(traj)
-# N is the maximum number of particles: max((len(f) for f in traj))
-# T is the number of particle types
+# M is the number of frames,
+# T is the number of particle types in a frame,
+# N is the number of particles in a frame
 ```
 
 Access properties of individual frames:
 ```python
 frame = traj[i]
-frame.box              # 3x3 matrix (not required to be upper-triangular)
-frame.types            # T
-frame.typeid           # N
+frame.N                # int, number of particles
+frame.box              # garnett.trajectory.Box object
+frame.types            # T, names for each type
+frame.type_shapes      # T, list of shapes for each type
+frame.typeid           # N, type indices of each particle
 frame.position         # Nx3
 frame.orientation      # Nx4
 frame.velocity         # Nx3
@@ -98,9 +104,9 @@ frame.charge           # N
 frame.diameter         # N
 frame.moment_inertia   # Nx3
 frame.angmom           # Nx4
-frame.data             # A dictionary of lists for each attribute
-frame.data_key         # A list of strings
-frame.type_shapes      # T, Shape for each type
+frame.image            # Nx3
+frame.data             # Dictionary of lists for each attribute
+frame.data_key         # List of strings
 ```
 
 All matrices are `numpy` arrays.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ sub_trajectory = traj[i:j]
 Access properties of trajectories:
 ```python
 traj.load_arrays()
+traj.N               # M
+traj.types           # MxT
+traj.typeid          # MxN
 traj.position        # MxNx3
 traj.orientation     # MxNx4
 traj.velocity        # MxNx3
@@ -77,19 +80,21 @@ traj.charge          # MxN
 traj.diameter        # MxN
 traj.moment_inertia  # MxNx3
 traj.angmom          # MxNx4
-traj.types           # MxT
+traj.image           # MxNx3
 
-# M is the number of frames: len(traj)
-# N is the maximum number of particles: max((len(f) for f in traj))
+# M is the number of frames
 # T is the number of particle types
+# N is the number of particles
 ```
 
 Access properties of individual frames:
 ```python
 frame = traj[i]
-frame.box              # 3x3 matrix (not required to be upper-triangular)
-frame.types            # T
-frame.typeid           # N
+frame.box              # garnett.trajectory.Box object
+frame.N                # scalar
+frame.types            # T, string names for each type
+frame.type_shapes      # T, instances of Shape for each type
+frame.typeid           # N, type indices
 frame.position         # Nx3
 frame.orientation      # Nx4
 frame.velocity         # Nx3
@@ -98,12 +103,12 @@ frame.charge           # N
 frame.diameter         # N
 frame.moment_inertia   # Nx3
 frame.angmom           # Nx4
-frame.data             # A dictionary of lists for each attribute
-frame.data_key         # A list of strings
-frame.type_shapes      # T, Shape for each type
+frame.image            # Nx3
+frame.data             # Dictionary of lists for each attribute
+frame.data_key         # List of strings
 ```
 
-All matrices are `numpy` arrays.
+All matrices are NumPy arrays.
 
 ## Example use with HOOMD-blue
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ frame.moment_inertia   # Nx3
 frame.angmom           # Nx4
 frame.data             # A dictionary of lists for each attribute
 frame.data_key         # A list of strings
-frame.shapedef         # A ordered dictionary of instances of ShapeDefinition
+frame.type_shapes      # T, Shape for each type
 ```
 
 All matrices are `numpy` arrays.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This is a collection of samples, parsers and writers for formats used in the Glo
 
 To install this package with pip, execute:
 
-    pip install garnett --user
+```bash
+pip install garnett --user
+```
 
 ## Documentation
 
@@ -28,15 +30,17 @@ To install this package with pip, execute:
 
 To build the documentation yourself using sphinx, execute within the repository:
 
-    cd doc
-    make html
-    open _build/html/index.html
+```bash
+cd doc
+make html
+open _build/html/index.html
+```
 
 ## Quickstart
 
 ### Reading and writing
 
-``` python
+```python
 import garnett
 
 # Autodetects file format for a uniform trajectory API
@@ -51,18 +55,19 @@ with garnett.read('posfile.pos') as traj:
 
 ### Data access
 
-Access individual frames by indexing or create sub trajectories with slicing:
+Access individual frames by indexing or create subsets of trajectories with slicing:
+
 ```python
 first_frame = traj[0]
 last_frame = traj[-1]
-n_th_frame = traj[n]
+nth_frame = traj[n]
 # and so on
 
 sub_trajectory = traj[i:j]
 ```
 
 Access properties of trajectories:
-```
+```python
 traj.load_arrays()
 traj.position        # MxNx3
 traj.orientation     # MxNx4
@@ -72,16 +77,19 @@ traj.charge          # MxN
 traj.diameter        # MxN
 traj.moment_inertia  # MxNx3
 traj.angmom          # MxNx4
-traj.types           # MxN
+traj.types           # MxT
 
-# where M=len(traj) and N=max((len(f) for f in traj))
+# M is the number of frames: len(traj)
+# N is the maximum number of particles: max((len(f) for f in traj))
+# T is the number of particle types
 ```
 
 Access properties of individual frames:
-```
+```python
 frame = traj[i]
 frame.box              # 3x3 matrix (not required to be upper-triangular)
-frame.types            # N
+frame.types            # T
+frame.typeid           # N
 frame.position         # Nx3
 frame.orientation      # Nx4
 frame.velocity         # Nx3
@@ -94,14 +102,14 @@ frame.data             # A dictionary of lists for each attribute
 frame.data_key         # A list of strings
 frame.shapedef         # A ordered dictionary of instances of ShapeDefinition
 ```
+
 All matrices are `numpy` arrays.
 
 ## Example use with HOOMD-blue
 
 See the [examples directory](https://github.com/glotzerlab/garnett/tree/master/examples) for additional examples.
 
-```
-#!python
+```python
 pos_reader = PosFileReader()
 with open('cube.pos') as posfile:
     traj = pos_reader.read(posfile)
@@ -113,13 +121,14 @@ system = init.read_snapshot(snapshot)
 # Restore last frame
 snapshot = system.take_snapshot()
 traj[-1].to_hoomd_snapshot(snapshot)
-
 ```
 
 ## Testing
 
 To run all garnett tests, `ddt`, HOOMD-blue (`hoomd`), and `pycifrw` must be installed in the testing environments.
 
-Execute the tests with
+Execute the tests with:
 
-    python -m unittest discover tests
+```bash
+python -m unittest discover tests
+```

--- a/bin/garnett2pos
+++ b/bin/garnett2pos
@@ -102,10 +102,10 @@ def wrap_into_box(frame):
 
 
 def color_by_type(frame):
-    if len(frame.shapedef) > len(COLORS):
+    if len(frame.type_shapes) > len(COLORS):
         raise RuntimeError("Number of types larger than color map!")
-    for sd, color in zip(frame.shapedef, COLORS):
-        frame.shapedef[sd].color = color
+    for type_shape, color in zip(frame.type_shapes, COLORS):
+        type_shape.color = color
     return frame
 
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -18,6 +18,7 @@ Added
 Changed
 +++++++
   - Updated GSD reader to use the GSD v2.0.0 API.
+  - Changed behavior of ``types``, ``typeid``, ``type_shapes`` to match HOOMD conventions.
 
 Fixed
 +++++

--- a/changelog.rst
+++ b/changelog.rst
@@ -20,6 +20,7 @@ Changed
   - Updated GSD reader to use the GSD v2.0.0 API.
   - Changed behavior of ``types``, ``typeid``, ``type_shapes`` to match HOOMD conventions.
   - Shapes can still be read from GSD via HOOMD-HPMC state but shapes are always written to ``type_shapes`` instead of the HPMC state.
+  - ``PosFileWriter`` requires the number of ``type_shapes`` to match the number of ``types``.
 
 Fixed
 +++++

--- a/changelog.rst
+++ b/changelog.rst
@@ -19,6 +19,7 @@ Changed
 +++++++
   - Updated GSD reader to use the GSD v2.0.0 API.
   - Changed behavior of ``types``, ``typeid``, ``type_shapes`` to match HOOMD conventions.
+  - Shapes can still be read from GSD via HOOMD-HPMC state but shapes are always written to ``type_shapes`` instead of the HPMC state.
 
 Fixed
 +++++
@@ -65,7 +66,7 @@ Added
 
 Changed
 +++++++
-  - GSD and GTAR writers now output shape information that adheres to the GSD shape visualization specification
+  - GSD and GTAR writers now output shape information that adheres to the GSD shape visualization specification.
 
 Removed
 +++++++

--- a/changelog.rst
+++ b/changelog.rst
@@ -28,9 +28,10 @@ Deprecated
 ++++++++++
   - The following ``Frame`` and ``Trajectory`` attributes have been deprecated:
 
-    - positions (now position)
-    - orientations (now orientation)
-    - velocities (now velocity)
+    - ``positions`` (now ``position``)
+    - ``orientations`` (now ``orientation``)
+    - ``velocities`` (now ``velocity``)
+    - ``shapedef`` dict has been replaced by ``type_shapes`` list. Until this feature is removed, altering shape definitions is only supported if the entire dictionary is set at once.
 
   - The following ``Frame`` methods have been deprecated:
 

--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -44,6 +44,7 @@ Bradley Dice, University of Michigan
     * GETAR file writer
     * Support for additional frame properties
     * Improved support for parsing and writing particle shapes
+    * Refactored ``types``, ``typeid``, ``type_shapes`` to match HOOMD conventions
 
 Sophie Youjung Lee, University of Michigan
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -84,6 +84,7 @@ Supported properties are listed below:
     traj.load_arrays()
     traj.N               # M
     traj.types           # MxT
+    traj.typeid          # MxN
     traj.position        # MxNx3
     traj.orientation     # MxNx4
     traj.velocity        # MxNx3
@@ -92,12 +93,11 @@ Supported properties are listed below:
     traj.diameter        # MxN
     traj.moment_inertia  # MxNx3
     traj.angmom          # MxNx4
-    traj.image           # MxNx4
-    traj.type_ids        # MxN
+    traj.image           # MxNx3
 
-    # where M is the number of frames,
-    # T is the number of particle types in a frame,
-    # and N is the number of particles in a frame
+    # M is the number of frames
+    # T is the number of particle types
+    # N is the number of particles
 
 Individual frame access
 -----------------------
@@ -108,8 +108,10 @@ Inidividual frame objects can be accessed via indexing of a (sub-)trajectory obj
 
     frame = traj[i]
     frame.box              # garnett.trajectory.Box object
-    frame.types            # T
-    frame.typeid           # N
+    frame.N                # scalar
+    frame.types            # T, string names for each type
+    frame.type_shapes      # T, instances of Shape for each type
+    frame.typeid           # N, type indices
     frame.position         # Nx3
     frame.orientation      # Nx4
     frame.velocity         # Nx3
@@ -118,9 +120,9 @@ Inidividual frame objects can be accessed via indexing of a (sub-)trajectory obj
     frame.diameter         # N
     frame.moment_inertia   # Nx3
     frame.angmom           # Nx4
-    frame.data             # A dictionary of lists for each attribute
-    frame.data_key         # A list of strings
-    frame.type_shapes      # A list of instances of Shape for each type
+    frame.image            # Nx3
+    frame.data             # Dictionary of lists for each attribute
+    frame.data_key         # List of strings
 
 Iterating over trajectories
 ---------------------------

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -119,7 +119,7 @@ Inidividual frame objects can be accessed via indexing of a (sub-)trajectory obj
     frame.angmom           # Nx4
     frame.data             # A dictionary of lists for each attribute
     frame.data_key         # A list of strings
-    frame.shapedef         # A ordered dictionary of instances of ShapeDefinition
+    frame.type_shapes      # A list of instances of Shape for each type
 
 Iterating over trajectories
 ---------------------------

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -83,6 +83,7 @@ Supported properties are listed below:
 
     traj.load_arrays()
     traj.N               # M
+    traj.types           # MxT
     traj.position        # MxNx3
     traj.orientation     # MxNx4
     traj.velocity        # MxNx3
@@ -92,12 +93,11 @@ Supported properties are listed below:
     traj.moment_inertia  # MxNx3
     traj.angmom          # MxNx4
     traj.image           # MxNx4
-    traj.types           # MxN
     traj.type_ids        # MxN
-    traj.type            # list of type names ordered by type_id
 
-    # where M=len(traj) is the number of frames and N=max((len(f) for f in traj))
-    # is the is the maximum number of particles in any frame.
+    # where M is the number of frames,
+    # T is the number of particle types in a frame,
+    # and N is the number of particles in a frame
 
 Individual frame access
 -----------------------
@@ -108,7 +108,8 @@ Inidividual frame objects can be accessed via indexing of a (sub-)trajectory obj
 
     frame = traj[i]
     frame.box              # garnett.trajectory.Box object
-    frame.types            # N
+    frame.types            # T
+    frame.typeid           # N
     frame.position         # Nx3
     frame.orientation      # Nx4
     frame.velocity         # Nx3

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -84,6 +84,8 @@ Supported properties are listed below:
     traj.load_arrays()
     traj.N               # M
     traj.types           # MxT
+    traj.type_shapes     # MxT
+    traj.typeid          # MxN
     traj.position        # MxNx3
     traj.orientation     # MxNx4
     traj.velocity        # MxNx3
@@ -92,12 +94,11 @@ Supported properties are listed below:
     traj.diameter        # MxN
     traj.moment_inertia  # MxNx3
     traj.angmom          # MxNx4
-    traj.image           # MxNx4
-    traj.type_ids        # MxN
+    traj.image           # MxNx3
 
-    # where M is the number of frames,
+    # M is the number of frames,
     # T is the number of particle types in a frame,
-    # and N is the number of particles in a frame
+    # N is the number of particles in a frame
 
 Individual frame access
 -----------------------
@@ -107,9 +108,11 @@ Inidividual frame objects can be accessed via indexing of a (sub-)trajectory obj
 .. code-block:: python
 
     frame = traj[i]
+    frame.N                # int, number of particles
     frame.box              # garnett.trajectory.Box object
-    frame.types            # T
-    frame.typeid           # N
+    frame.types            # T, names for each type
+    frame.type_shapes      # T, list of shapes for each type
+    frame.typeid           # N, type indices of each particle
     frame.position         # Nx3
     frame.orientation      # Nx4
     frame.velocity         # Nx3
@@ -118,9 +121,9 @@ Inidividual frame objects can be accessed via indexing of a (sub-)trajectory obj
     frame.diameter         # N
     frame.moment_inertia   # Nx3
     frame.angmom           # Nx4
-    frame.data             # A dictionary of lists for each attribute
-    frame.data_key         # A list of strings
-    frame.type_shapes      # A list of instances of Shape for each type
+    frame.image            # Nx3
+    frame.data             # Dictionary of lists for each attribute
+    frame.data_key         # List of strings
 
 Iterating over trajectories
 ---------------------------

--- a/garnett/ciffilereader.py
+++ b/garnett/ciffilereader.py
@@ -142,6 +142,11 @@ class CifFileFrame(Frame):
 
         space_group_keys = ['_symmetry_equiv_pos_as_xyz', '_space_group_symop_operation_xyz']
         found_keys = [key for key in space_group_keys if key in self.parsed]
+
+        unique_points = []
+        types = []
+        typeid = []
+
         if found_keys:
             key_to_use = found_keys[0]
             symmetry_ops = [PARSE_DIVISION_REGEXP.sub(
@@ -150,22 +155,21 @@ class CifFileFrame(Frame):
 
             replicated_fractions = []
             replicated_types = []
-            for (typ, (fx, fy, fz)) in zip(site_types, fractions):
+            for (type_name, (fx, fy, fz)) in zip(site_types, fractions):
                 extra_fractions = [eval(sym, dict(x=fx, y=fy, z=fz)) for sym in symmetry_ops]
                 replicated_fractions.extend(extra_fractions)
-                replicated_types.extend(len(extra_fractions)*[typ])
+                replicated_types.extend(len(extra_fractions)*[type_name])
             # wrap back into the box
             replicated_fractions -= np.floor(replicated_fractions)
             replicated_fractions = dict(enumerate(np.array(replicated_fractions, dtype=np.float32)))
 
-            unique_points = []
-            types = []
             bad_types = False
             # short of using scipy or freud, we just exhaustively search
             # for points near each point to find symmetry-induced duplicates
             while len(replicated_fractions):
                 (ref_index, ref_point) = replicated_fractions.popitem()
-                types.append(replicated_types[ref_index])
+                print(ref_index, ref_point)
+                type_name = replicated_types[ref_index]
 
                 # set of points that are ~equivalent to ref_point given a tolerance
                 current_points = [ref_point]
@@ -186,18 +190,23 @@ class CifFileFrame(Frame):
                                    'position, the types for this file are invalid.')
                             warnings.warn(msg, ParserWarning)
 
+                if type_name not in types:
+                    types.append(type_name)
+                typeid.append(types.index(type_name))
                 unique_points.append(np.mean(current_points, axis=0))
             unique_points = np.array(unique_points, dtype=np.float32)
 
             if bad_types:
-                unique_types = len(unique_points)*[self.default_type]
-            else:
-                unique_types = types
+                types = [self.default_type]
+                typeid = np.zeros(len(unique_points), dtype=np.uint)
         else:
+            for type_name in site_types:
+                if type_name not in types:
+                    types.append(type_name)
+                typeid.append(types.index(type_name))
             unique_points = fractions
-            unique_types = site_types
 
-        # Safe the exact points
+        # Save the exact points
         cif_coordinates = unique_points.copy()
 
         # shift so that (0, 0, 0) in fractional coordinates goes to a
@@ -207,9 +216,12 @@ class CifFileFrame(Frame):
         coordinates = np.sum(
             unique_points[:, np.newaxis, :]*box_matrix[np.newaxis, :, :], axis=2)
 
+        types = np.asarray(types, dtype=str)
+        typeid = np.asarray(typeid, dtype=np.uint)
         raw_frame = _RawFrameData()
         raw_frame.box = box_matrix
-        raw_frame.types = unique_types
+        raw_frame.types = types
+        raw_frame.typeid = typeid
         raw_frame.position = coordinates
         raw_frame.cif_coordinates = cif_coordinates
         return raw_frame

--- a/garnett/ciffilereader.py
+++ b/garnett/ciffilereader.py
@@ -167,7 +167,6 @@ class CifFileFrame(Frame):
             # for points near each point to find symmetry-induced duplicates
             while len(replicated_fractions):
                 (ref_index, ref_point) = replicated_fractions.popitem()
-                print(ref_index, ref_point)
                 type_name = replicated_types[ref_index]
 
                 # set of points that are ~equivalent to ref_point given a tolerance

--- a/garnett/ciffilewriter.py
+++ b/garnett/ciffilewriter.py
@@ -117,7 +117,8 @@ class CifFileWriter(object):
         type_counter = defaultdict(int)
         n_digits = len(str(len(frame.position)))
         particle_str = "{ptype}{pnum:0" + str(n_digits) + "d} {ptype} {occ:3.2f} {position}"
-        for i, (position, particle_type, occupancy) in enumerate(zip(fractions, frame.types, occupancies)):
+        for i, (position, typeid, occupancy) in enumerate(zip(fractions, frame.typeid, occupancies)):
+            particle_type = frame.types[typeid]
             _write(particle_str.format(
                 pnum=type_counter[particle_type],
                 ptype=particle_type,

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -49,7 +49,7 @@ from numpy.core import numeric as _nx
 from numpy.core.numeric import asanyarray
 
 from .trajectory import Frame, Trajectory
-from .trajectory import _RawFrameData, _generate_type_id_array
+from .trajectory import _RawFrameData
 from . import pydcdreader
 
 logger = logging.getLogger(__name__)

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -147,7 +147,7 @@ class DCDFrame(Frame):
         self._position = xyz.swapaxes(0, 1)
 
     def _load(self, xyz=None, ort=None):
-        N = int(self.file_header.n_particles)
+        N = np.uint(self.file_header.n_particles)
         if xyz is None:
             xyz = np.zeros((3, N), dtype=np.float32)
         if ort is None:
@@ -157,8 +157,8 @@ class DCDFrame(Frame):
             self._types = [self.default_type]
             self._typeid = np.zeros(N, dtype=np.uint)
         else:
-            self._types = self.t_frame.types
-            self._typeid = self.t_frame.typeid
+            self._types = copy.copy(self.t_frame.types)
+            self._typeid = copy.copy(self.t_frame.typeid)
         if self.t_frame is None or self.t_frame.box.dimensions == 3:
             ort.T[0] = 1.0
             ort.T[1:] = 0
@@ -228,7 +228,7 @@ class DCDTrajectory(Trajectory):
         # Determine array shapes
         M = len(self)
         N = len(self.frames[0])
-        _N = np.ones(M) * N
+        _N = np.ones(M, dtype=np.uint) * N
 
         # Coordinates
         xyz = np.zeros((M, 3, N), dtype=np.float32)

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -49,6 +49,7 @@ from numpy.core import numeric as _nx
 from numpy.core.numeric import asanyarray
 
 from .trajectory import Frame, Trajectory
+from .trajectory import FRAME_PROPERTIES, TYPE_PROPERTIES, PARTICLE_PROPERTIES
 from .trajectory import _RawFrameData
 from . import pydcdreader
 
@@ -147,15 +148,16 @@ class DCDFrame(Frame):
         self._position = xyz.swapaxes(0, 1)
 
     def _load(self, xyz=None, ort=None):
-        N = np.uint(self.file_header.n_particles)
+        N = FRAME_PROPERTIES['N'](self.file_header.n_particles)
         if xyz is None:
             xyz = np.zeros((3, N), dtype=np.float32)
         if ort is None:
             ort = np.zeros((N, 4), dtype=self._dtype)
         self._read(xyz=xyz)
         if self.t_frame is None:
-            self._types = [self.default_type]
-            self._typeid = np.zeros(N, dtype=np.uint)
+            self._types = np.asarray([self.default_type],
+                                     dtype=TYPE_PROPERTIES['types'])
+            self._typeid = np.zeros(N, dtype=PARTICLE_PROPERTIES['typeid'])
         else:
             self._types = copy.copy(self.t_frame.types)
             self._typeid = copy.copy(self.t_frame.typeid)
@@ -228,7 +230,7 @@ class DCDTrajectory(Trajectory):
         # Determine array shapes
         M = len(self)
         N = len(self.frames[0])
-        _N = np.full(M, N, dtype=np.uint)
+        _N = np.full(M, N, dtype=FRAME_PROPERTIES['N'])
 
         # Coordinates
         xyz = np.zeros((M, 3, N), dtype=np.float32)
@@ -238,8 +240,10 @@ class DCDTrajectory(Trajectory):
                 frame._load(xyz=xyz[i], ort=ort[i])
 
         # Types can only be handled after frame._load() calls.
-        types = np.asarray([f._types for f in self.frames])
-        typeid = np.asarray([f._typeid for f in self.frames])
+        types = np.asarray([f._types for f in self.frames],
+                           dtype=TYPE_PROPERTIES['types'])
+        typeid = np.asarray([f._typeid for f in self.frames],
+                            dtype=PARTICLE_PROPERTIES['typeid'])
 
         try:
             # Perform swap

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -157,8 +157,8 @@ class DCDFrame(Frame):
             self._types = [self.default_type]
             self._typeid = np.zeros(N, dtype=np.uint)
         else:
-            self._types = self.t_frame.types
-            self._typeid = self.t_frame.typeid
+            self._types = copy.copy(self.t_frame.types)
+            self._typeid = copy.copy(self.t_frame.typeid)
         if self.t_frame is None or self.t_frame.box.dimensions == 3:
             ort.T[0] = 1.0
             ort.T[1:] = 0

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -131,6 +131,7 @@ class DCDFrame(Frame):
         self.t_frame = t_frame
         self.default_type = default_type
         self._types = None
+        self._typeid = None
         self._box = None
         self._position = None
         self._orientation = None
@@ -153,9 +154,11 @@ class DCDFrame(Frame):
             ort = np.zeros((N, 4), dtype=self._dtype)
         self._read(xyz=xyz)
         if self.t_frame is None:
-            self._types = [self.default_type] * len(self)
+            self._types = [self.default_type]
+            self._typeid = np.zeros(N, dtype=np.uint)
         else:
             self._types = self.t_frame.types
+            self._typeid = self.t_frame.typeid
         if self.t_frame is None or self.t_frame.box.dimensions == 3:
             ort.T[0] = 1.0
             ort.T[1:] = 0
@@ -169,6 +172,7 @@ class DCDFrame(Frame):
 
     def _loaded(self):
         return not (self._types is None or
+                    self._typeid is None or
                     self._box is None or
                     self._position is None or
                     self._orientation is None)
@@ -180,17 +184,18 @@ class DCDFrame(Frame):
             raw_frame.data_keys = copy.deepcopy(self.t_frame.data_keys)
             raw_frame.box_dimensions = self.t_frame.box.dimensions
             try:
-                raw_frame.shapedef = copy.deepcopy(self.t_frame.shapedef)
+                raw_frame.type_shapes = copy.deepcopy(self.t_frame.type_shapes)
             except AttributeError:
                 pass
         if not self._loaded():
             self._load()
         assert self._loaded()
         raw_frame.box = self._box
-        raw_frame.types = copy.copy(self._types)
+        raw_frame.types = self._types
+        raw_frame.typeid = self._typeid
         raw_frame.position = self._position
         raw_frame.orientation = self._orientation
-        assert len(raw_frame.types) == len(self)
+        assert len(raw_frame.typeid) == len(self)
         assert len(raw_frame.position) == len(self)
         assert len(raw_frame.orientation) == len(self)
         return raw_frame
@@ -214,9 +219,8 @@ class DCDTrajectory(Trajectory):
 
         See also: :meth:`~.load_arrays`"""
         return not (self._N is None or
-                    self._type is None or
                     self._types is None or
-                    self._type_ids is None or
+                    self._typeid is None or
                     self._position is None or
                     self._orientation is None)
 
@@ -233,17 +237,15 @@ class DCDTrajectory(Trajectory):
             if not frame._loaded():
                 frame._load(xyz=xyz[i], ort=ort[i])
 
-        # Types, Can only be handled after frame._load() calls.
-        types = [f._types for f in self.frames]
-        type_ids = np.zeros((len(self), N), dtype=np.int_)
-        _type = _generate_type_id_array(types, type_ids)
+        # Types can only be handled after frame._load() calls.
+        types = np.asarray([f._types for f in self.frames])
+        typeid = np.asarray([f._typeid for f in self.frames])
 
         try:
             # Perform swap
             self._N = _N
-            self._type = _type
             self._types = types
-            self._type_ids = type_ids
+            self._typeid = typeid
             self._position = xyz.swapaxes(1, 2)
             self._orientation = ort
         except Exception:

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -228,7 +228,7 @@ class DCDTrajectory(Trajectory):
         # Determine array shapes
         M = len(self)
         N = len(self.frames[0])
-        _N = np.ones(M, dtype=np.uint) * N
+        _N = np.full(M, N, dtype=np.uint)
 
         # Coordinates
         xyz = np.zeros((M, 3, N), dtype=np.float32)

--- a/garnett/errors.py
+++ b/garnett/errors.py
@@ -9,7 +9,3 @@ class ParserError(RuntimeError):
 
 class ParserWarning(RuntimeWarning):
     pass
-
-
-class GSDShapeError(RuntimeError):
-    pass

--- a/garnett/getarfilereader.py
+++ b/garnett/getarfilereader.py
@@ -11,12 +11,10 @@ Authors: Matthew Spellings, Carl Simon Adorf
     traj = reader.read(open('trajectory.tar', 'rb'))
 """
 
+import gtar
 import json
 import logging
-import collections
-
 import numpy as np
-import gtar
 
 from .trajectory import _RawFrameData, Box, Frame, Trajectory
 from .shapes import _parse_type_shape

--- a/garnett/getarfilereader.py
+++ b/garnett/getarfilereader.py
@@ -47,12 +47,20 @@ class GetarFrame(Frame):
 
     def read(self):
         raw_frame = _RawFrameData()
-        raw_frame.shapedef = collections.OrderedDict()
-        prop_map = {'angular_momentum_quat': 'angmom'}
-        supported_records = ['position', 'orientation', 'velocity',
-                             'mass', 'charge', 'diameter',
-                             'moment_inertia', 'angular_momentum_quat',
-                             'image']
+        raw_frame.type_shapes = []
+
+        # Map getar field names onto HOOMD convention's names
+        prop_map = {
+            'angular_momentum_quat': 'angmom',
+            'type': 'typeid',
+        }
+
+        supported_records = [
+            'type', 'position', 'orientation', 'velocity',
+            'mass', 'charge', 'diameter',
+            'moment_inertia', 'angular_momentum_quat',
+            'image'
+        ]
         for name in supported_records:
             try:
                 values = self._trajectory.getRecord(
@@ -65,13 +73,10 @@ class GetarFrame(Frame):
                 setattr(raw_frame, frame_prop, values)
 
         if 'type' in self._records and 'type_names.json' in self._records:
-            names = json.loads(self._trajectory.getRecord(
+            raw_frame.types = json.loads(self._trajectory.getRecord(
                 self._records['type_names.json'], self._frame))
-            types = self._trajectory.getRecord(
-                self._records['type'], self._frame)
-            raw_frame.types = [names[t] for t in types]
         else:
-            raw_frame.types = len(raw_frame.position) * [self._default_type]
+            raw_frame.types = [self._default_type]
 
         if 'box' in self._records:
             # Read dimension if stored
@@ -94,14 +99,10 @@ class GetarFrame(Frame):
         else:
             raw_frame.box = self._default_box
 
-        if 'type_names.json' in self._records and 'type_shapes.json' in self._records:
-            names = json.loads(self._trajectory.getRecord(
-                self._records['type_names.json'], self._frame))
-            shapes = json.loads(self._trajectory.getRecord(
+        if 'type_shapes.json' in self._records:
+            type_shapes = json.loads(self._trajectory.getRecord(
                 self._records['type_shapes.json'], self._frame))
-            for name, shape in zip(names, shapes):
-                shape_def = _parse_type_shape(shape)
-                raw_frame.shapedef.update({name: shape_def})
+            raw_frame.type_shapes = [_parse_type_shape(t) for t in type_shapes]
 
         return raw_frame
 

--- a/garnett/getarfilewriter.py
+++ b/garnett/getarfilewriter.py
@@ -13,7 +13,6 @@ Authors: Bradley Dice
 """
 
 from gtar import GTAR, Record
-import numpy as np
 import json
 import logging
 logger = logging.getLogger(__name__)

--- a/garnett/getarfilewriter.py
+++ b/garnett/getarfilewriter.py
@@ -41,6 +41,7 @@ class GetarFileWriter(object):
     """
 
     property_record_map = {
+        'typeid': 'type.u32.ind',
         'position': 'position.f32.ind',
         'orientation': 'orientation.f32.ind',
         'velocity': 'velocity.f32.ind',
@@ -64,17 +65,10 @@ class GetarFileWriter(object):
     def writeFrame(self, bulkwriter, frame, index=None, skip_props=False):
         """Write the frame data for an index using a bulk writer."""
 
-        # Types
-        type_rec = self.makeRecord('type.u32.ind', index=index)
-        types = list(set(frame.types))
-        type_contents = np.array([types.index(t) for t in frame.types],
-                                 dtype=np.uint32)
-        bulkwriter.writeRecord(rec=type_rec, contents=type_contents)
-
         # Type names
-        name_rec = self.makeRecord('type_names.json', index=index)
-        name_contents = json.dumps(types)
-        bulkwriter.writeRecord(rec=name_rec, contents=name_contents)
+        types_rec = self.makeRecord('type_names.json', index=index)
+        types_contents = json.dumps(frame.types)
+        bulkwriter.writeRecord(rec=types_rec, contents=types_contents)
 
         if not skip_props:
             # Particle properties
@@ -90,19 +84,11 @@ class GetarFileWriter(object):
         bulkwriter.writeRecord(rec=dim_rec, contents=[frame.box.dimensions])
 
         # Shape definitions
-        shape_rec = self.makeRecord('type_shapes.json', index=index)
-        shape_contents = []
-        for typename in types:
-            try:
-                shape_contents.append(frame.shapedef[typename].type_shape)
-            except AttributeError:
-                shape_contents.append(None)
-            except KeyError:
-                logger.info('Type name \'{}\' has no stored shape information.'.format(
-                    typename))
-                shape_contents.append(None)
-        shape_contents = json.dumps(shape_contents)
-        bulkwriter.writeRecord(rec=shape_rec, contents=shape_contents)
+        type_shapes = getattr(frame, 'type_shapes', None)
+        if type_shapes is not None:
+            shape_rec = self.makeRecord('type_shapes.json', index=index)
+            type_shapes = json.dumps([t.type_shape for t in type_shapes])
+            bulkwriter.writeRecord(rec=shape_rec, contents=type_shapes)
 
     def write(self, trajectory, stream, static_frame=None):
         """Serialize a trajectory into gtar-format and write it to a file.

--- a/garnett/gsdhoomdfilereader.py
+++ b/garnett/gsdhoomdfilereader.py
@@ -29,7 +29,6 @@ This example reads shape data from a HOOMD-blue POS frame:
 import logging
 import warnings
 import copy
-import collections
 
 import numpy as np
 
@@ -63,7 +62,6 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
     This method uses the ``type_shapes`` property if it is set. Otherwise it
     falls back to reading HPMC state data and inferring ``type_shapes``.
     """
-
 
     def get_chunk(i, chunk, default=None):
         if gsdfile.chunk_exists(i, chunk):

--- a/garnett/gsdhoomdfilereader.py
+++ b/garnett/gsdhoomdfilereader.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 The Regents of the University of Michigan
 # All rights reserved.
 # This software is licensed under the BSD 3-Clause License.
-"""Hoomd-GSD-file reader for the Glotzer Group, University of Michigan.
+"""HOOMD-blue GSD file reader for the Glotzer Group, University of Michigan.
 
 Author: Carl Simon Adorf
 
@@ -13,7 +13,7 @@ To provide additional information it is possible
 to pass a frame object, whose properties
 are copied into each frame of the gsd trajectory.
 
-The example is given for a hoomd-blue xml frame:
+This example reads shape data from a HOOMD-blue POS frame:
 
 .. code::
 
@@ -58,6 +58,12 @@ def _box_matrix(box):
 
 
 def _parse_shape_definitions(frame, gsdfile, frame_index):
+    """Parses shape information for a frame in a GSD file.
+
+    This method uses the ``type_shapes`` property if it is set. Otherwise it
+    falls back to reading HPMC state data and inferring ``type_shapes``.
+    """
+
 
     def get_chunk(i, chunk, default=None):
         if gsdfile.chunk_exists(i, chunk):
@@ -67,24 +73,17 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
         else:
             return default
 
-    shapedefs = collections.OrderedDict()
-    types = frame.particles.types
-
     if get_chunk(frame_index, 'particles/type_shapes') is not None:
         # --------------------------------------------------
         # Parsing from GSD Shape Visualization Specification
         # --------------------------------------------------
-
-        type_shapes = frame.particles.type_shapes
-        for typename, type_shape in zip(types, type_shapes):
-            shapedefs[typename] = _parse_type_shape(type_shape)
-        return shapedefs
+        return [_parse_type_shape(t) for t in frame.particles.type_shapes]
     else:
-
         # -----------------------
         # Parsing from HPMC State
         # -----------------------
 
+        type_shapes = []
         # Spheres
         if get_chunk(frame_index, 'state/hpmc/sphere/radius') is not None:
             radii = get_chunk(frame_index, 'state/hpmc/sphere/radius')
@@ -93,10 +92,11 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
             # not all GSD files may have it. Thus, it is set to False in such cases.
             if orientables is None:
                 orientables = [False]*len(radii)
-            for typename, radius, orientable in zip(types, radii, orientables):
-                shapedefs[typename] = SphereShape(
+            for radius, orientable in zip(radii, orientables):
+                shape = SphereShape(
                     diameter=radius*2, orientable=orientable, color=None)
-            return shapedefs
+                type_shapes.append(shape)
+            return type_shapes
 
         # Convex Polyhedra
         elif get_chunk(frame_index, 'state/hpmc/convex_polyhedron/N') is not None:
@@ -105,10 +105,11 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
             N_end = [sum(N[:i+1]) for i in range(len(N))]
             verts = get_chunk(frame_index, 'state/hpmc/convex_polyhedron/vertices')
             verts_split = [verts[start:end] for start, end in zip(N_start, N_end)]
-            for typename, typeverts in zip(types, verts_split):
-                shapedefs[typename] = ConvexPolyhedronShape(
+            for typeverts in verts_split:
+                shape = ConvexPolyhedronShape(
                     vertices=typeverts, color=None)
-            return shapedefs
+                type_shapes.append(shape)
+            return type_shapes
 
         # Convex Spheropolyhedra
         elif get_chunk(frame_index, 'state/hpmc/convex_spheropolyhedron/N') is not None:
@@ -120,20 +121,22 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
             verts_split = [verts[start:end] for start, end in zip(N_start, N_end)]
             sweep_radii = get_chunk(frame_index,
                                     'state/hpmc/convex_spheropolyhedron/sweep_radius')
-            for typename, typeverts, radius in zip(types, verts_split, sweep_radii):
-                shapedefs[typename] = ConvexSpheropolyhedronShape(
+            for typeverts, radius in zip(verts_split, sweep_radii):
+                shape = ConvexSpheropolyhedronShape(
                     vertices=typeverts, rounding_radius=radius, color=None)
-            return shapedefs
+                type_shapes.append(shape)
+            return type_shapes
 
         # Ellipsoid
         elif get_chunk(frame_index, 'state/hpmc/ellipsoid/a') is not None:
             a_all = get_chunk(frame_index, 'state/hpmc/ellipsoid/a')
             b_all = get_chunk(frame_index, 'state/hpmc/ellipsoid/b')
             c_all = get_chunk(frame_index, 'state/hpmc/ellipsoid/c')
-            for typename, a, b, c in zip(types, a_all, b_all, c_all):
-                shapedefs[typename] = EllipsoidShape(
+            for a, b, c in zip(a_all, b_all, c_all):
+                shape = EllipsoidShape(
                     a=a, b=b, c=c, color=None)
-            return shapedefs
+                type_shapes.append(shape)
+            return type_shapes
 
         # Convex Polygons
         elif get_chunk(frame_index, 'state/hpmc/convex_polygon/N') is not None:
@@ -142,10 +145,11 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
             N_end = [sum(N[:i+1]) for i in range(len(N))]
             verts = get_chunk(frame_index, 'state/hpmc/convex_polygon/vertices')
             verts_split = [verts[start:end] for start, end in zip(N_start, N_end)]
-            for typename, typeverts in zip(types, verts_split):
-                shapedefs[typename] = PolygonShape(
+            for typeverts in verts_split:
+                shape = PolygonShape(
                     vertices=typeverts, color=None)
-            return shapedefs
+                type_shapes.append(shape)
+            return type_shapes
 
         # Convex Spheropolygons
         elif get_chunk(frame_index, 'state/hpmc/convex_spheropolygon/N') is not None:
@@ -156,10 +160,11 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
             verts_split = [verts[start:end] for start, end in zip(N_start, N_end)]
             sweep_radii = get_chunk(frame_index,
                                     'state/hpmc/convex_spheropolygon/sweep_radius')
-            for typename, typeverts, radius in zip(types, verts_split, sweep_radii):
-                shapedefs[typename] = SpheropolygonShape(
+            for typeverts, radius in zip(verts_split, sweep_radii):
+                shape = SpheropolygonShape(
                     vertices=typeverts, rounding_radius=radius, color=None)
-            return shapedefs
+                type_shapes.append(shape)
+            return type_shapes
 
         # Simple Polygons
         elif get_chunk(frame_index, 'state/hpmc/simple_polygon/N') is not None:
@@ -168,10 +173,11 @@ def _parse_shape_definitions(frame, gsdfile, frame_index):
             N_end = [sum(N[:i+1]) for i in range(len(N))]
             verts = get_chunk(frame_index, 'state/hpmc/simple_polygon/vertices')
             verts_split = [verts[start:end] for start, end in zip(N_start, N_end)]
-            for typename, typeverts in zip(types, verts_split):
-                shapedefs[typename] = PolygonShape(
+            for typeverts in verts_split:
+                shape = PolygonShape(
                     vertices=typeverts, color=None)
-            return shapedefs
+                type_shapes.append(shape)
+            return type_shapes
 
         # If no shapes were detected, return None
         else:
@@ -218,15 +224,16 @@ class GSDHoomdFrame(Frame):
             raw_frame.data_keys = copy.deepcopy(self.t_frame.data_keys)
             raw_frame.box_dimensions = self.t_frame.box.dimensions
             try:
-                raw_frame.shapedef = copy.deepcopy(self.t_frame.shapedef)
+                raw_frame.type_shapes = copy.deepcopy(self.t_frame.type_shapes)
             except AttributeError:
                 pass
         else:
             # Fallback to gsd shape data if no frame is provided
-            raw_frame.shapedef = _parse_shape_definitions(frame, self.gsdfile, self.frame_index)
+            raw_frame.type_shapes = _parse_shape_definitions(frame, self.gsdfile, self.frame_index)
         raw_frame.box = _box_matrix(frame.configuration.box)
         raw_frame.box_dimensions = int(frame.configuration.dimensions)
-        raw_frame.types = [frame.particles.types[t] for t in frame.particles.typeid]
+        raw_frame.types = frame.particles.types
+        raw_frame.typeid = frame.particles.typeid
         raw_frame.position = frame.particles.position
         raw_frame.orientation = frame.particles.orientation
         raw_frame.velocity = frame.particles.velocity
@@ -243,7 +250,7 @@ class GSDHoomdFrame(Frame):
 
 
 class GSDHOOMDFileReader(object):
-    """Hoomd-GSD-file reader for the Glotzer Group, University of Michigan.
+    """HOOMD-blue GSD file reader for the Glotzer Group, University of Michigan.
 
     Author: Carl Simon Adorf
 

--- a/garnett/gsdhoomdfilewriter.py
+++ b/garnett/gsdhoomdfilewriter.py
@@ -75,6 +75,5 @@ class GSDHOOMDFileWriter(object):
                         setattr(snap.particles, prop, getattr(frame, prop))
                     except AttributeError:
                         pass
-
                 traj_outfile.append(snap)
                 logger.debug("Wrote frame {}.".format(i + 1))

--- a/garnett/gsdhoomdfilewriter.py
+++ b/garnett/gsdhoomdfilewriter.py
@@ -10,11 +10,6 @@ Author: Vyas Ramasubramani
 import gsd
 import gsd.hoomd
 import logging
-import numpy as np
-
-from .shapes import SphereShape, ConvexPolyhedronShape, ConvexSpheropolyhedronShape, \
-    PolygonShape, SpheropolygonShape, EllipsoidShape
-from .errors import GSDShapeError
 
 from .trajectory import PARTICLE_PROPERTIES
 

--- a/garnett/hoomdxmlfilereader.py
+++ b/garnett/hoomdxmlfilereader.py
@@ -18,7 +18,7 @@ import xml.etree.ElementTree as ET
 
 import numpy as np
 
-from .trajectory import _RawFrameData, Frame, Trajectory
+from .trajectory import _RawFrameData, Frame, Trajectory, _generate_types_typeid
 from .errors import ParserError
 
 
@@ -110,13 +110,8 @@ def _parse_orientation(orientation):
 
 
 def _parse_types(types_element):
-    types = []
-    typeid = []
-    for typ in types_element.text.splitlines()[1:]:
-        typ = str(typ)
-        if typ not in types:
-            types.append(typ)
-        typeid.append(types.index(typ))
+    type_strings = types_element.text.splitlines()[1:]
+    types, typeid = _generate_types_typeid(type_strings)
     if len(typeid) != int(types_element.attrib.get('num', -1)):
         warnings.warn("Number of types is inconsistent.")
     return types, typeid

--- a/garnett/hoomdxmlfilereader.py
+++ b/garnett/hoomdxmlfilereader.py
@@ -45,7 +45,7 @@ class HOOMDXMLFrame(Frame):
         if velocity is not None:
             raw_frame.velocity = list(_parse_velocity(velocity))
 
-        raw_frame.types = list(_parse_types(config.find('type')))
+        raw_frame.types, raw_frame.typeid = _parse_types(config.find('type'))
         return raw_frame
 
     def __str__(self):
@@ -109,8 +109,14 @@ def _parse_orientation(orientation):
         warnings.warn("Number of orientations is inconsistent.")
 
 
-def _parse_types(types):
-    for i, type in enumerate(types.text.splitlines()[1:]):
-        yield str(type)
-    if i + 1 != int(types.attrib.get('num', i)):
+def _parse_types(types_element):
+    types = []
+    typeid = []
+    for typ in types_element.text.splitlines()[1:]:
+        typ = str(typ)
+        if typ not in types:
+            types.append(typ)
+        typeid.append(types.index(typ))
+    if len(typeid) != int(types_element.attrib.get('num', -1)):
         warnings.warn("Number of types is inconsistent.")
+    return types, typeid

--- a/garnett/posfilereader.py
+++ b/garnett/posfilereader.py
@@ -225,7 +225,6 @@ class PosFileFrame(Frame):
                     "Failed to read line #{}: {}.".format(i, line))
         monotype = False
         raw_frame = _RawFrameData()
-        raw_frame.shapedef = collections.OrderedDict()
         raw_frame.view_rotation = None
         for i, line in enumerate(self.stream):
             if _is_comment(line):
@@ -251,15 +250,20 @@ class PosFileFrame(Frame):
                     definition, data, end = line.strip().split('"')
                     _assert(len(end) == 0)
                     name = definition.split()[1]
-                    if name in raw_frame.shapedef:
-                        warnings.warn("Redifinition of type '{}'.".format(name))
-                    raw_frame.shapedef[
-                        name] = self._parse_shape_definition(data)
+                    type_shape = self._parse_shape_definition(data)
+                    if name not in raw_frame.types:
+                        raw_frame.types.append(name)
+                        raw_frame.type_shapes.append(type_shape)
+                    else:
+                        typeid = raw_frame.type_shapes.index(name)
+                        raw_frame.type_shapes[typeid] = type_shape
+                        warnings.warn("Redefinition of type '{}'.".format(name))
                 elif tokens[0] == 'shape':  # monotype
-                    definition = line.strip().split('"')[1]
-                    raw_frame.shapedef[self.default_type] = \
-                        self._parse_shape_definition(definition)
-                    _assert(len(raw_frame.shapedef) == 1)
+                    data = line.strip().split('"')[1]
+                    raw_frame.types.append(self.default_type)
+                    type_shape = self._parse_shape_definition(data)
+                    raw_frame.type_shapes.append(type_shape)
+                    _assert(len(raw_frame.type_shapes) == 1)
                     monotype = True
                 elif tokens[0] in ('boxMatrix', 'box'):
                     if len(tokens) == 10:
@@ -278,13 +282,15 @@ class PosFileFrame(Frame):
                     # assume we are reading positions now
                     if not monotype:
                         name = tokens[0]
-                        if name not in raw_frame.shapedef:
-                            raw_frame.shapedef.setdefault(
-                                name, self._parse_shape_definition(' '.join(tokens[:3])))
+                        if name not in raw_frame.types:
+                            raw_frame.types.append(name)
+                            type_shape = self._parse_shape_definition(' '.join(tokens[:3]))
+                            raw_frame.type_shapes.append(type_shape)
                     else:
                         name = self.default_type
-                    if len(tokens) == 7 and isinstance(
-                            raw_frame.shapedef[name], ArrowShape):
+                    typeid = raw_frame.types.index(name)
+                    type_shape = raw_frame.type_shapes[typeid]
+                    if len(tokens) == 7 and isinstance(type_shape, ArrowShape):
                         xyz = tokens[-6:-3]
                         quat = tokens[-3:] + [0]
                     elif len(tokens) >= 7:
@@ -295,7 +301,7 @@ class PosFileFrame(Frame):
                         quat = None
                     else:
                         raise ParserError(line)
-                    raw_frame.types.append(name)
+                    raw_frame.typeid.append(typeid)
                     raw_frame.position.append([self._num(v) for v in xyz])
                     if quat is None:
                         raw_frame.orientation.append(quat)

--- a/garnett/posfilewriter.py
+++ b/garnett/posfilewriter.py
@@ -95,15 +95,10 @@ class PosFileWriter(object):
 
             # shape defs
             try:
-                required = [t for t in frame.types if t in frame.shapedef]
-                not_defined = [t for t in frame.types if t not in frame.shapedef]
-                for name in required:
-                    _write('def {} "{}"'.format(name, frame.shapedef[name].pos_string))
-                for name in not_defined:
-                    logger.info(
-                        "No shape defined for '{}'. "
-                        "Using fallback definition.".format(name))
-                    _write('def {} "{}"'.format(name, DEFAULT_SHAPE_DEFINITION.pos_string))
+                if len(frame.types) != len(frame.type_shapes):
+                    raise ValueError("Unequal number of types and type_shapes.")
+                for name, type_shape in zip(frame.types, frame.type_shapes):
+                    _write('def {} "{}"'.format(name, type_shape.pos_string))
             except AttributeError:
                 # If AttributeError is raised because the frame does not contain
                 # shape information, fill them all with the default shape

--- a/garnett/posfilewriter.py
+++ b/garnett/posfilewriter.py
@@ -119,8 +119,8 @@ class PosFileWriter(object):
             # If the frame does not have orientations, identity quaternions are used
             orientation = getattr(frame, 'orientation', np.array([[1, 0, 0, 0]] * len(frame.types)))
 
-            for name, pos, rot in zip(frame.types, frame.position, orientation):
-
+            for typeid, pos, rot in zip(frame.typeid, frame.position, orientation):
+                name = frame.types[typeid]
                 _write(name, end=' ')
                 try:
                     shapedef = frame.shapedef.get(name)

--- a/garnett/posfilewriter.py
+++ b/garnett/posfilewriter.py
@@ -95,10 +95,8 @@ class PosFileWriter(object):
 
             # shape defs
             try:
-                required = set(frame.types).intersection(
-                    set(frame.shapedef.keys()))
-                not_defined = set(frame.types).difference(
-                    set(frame.shapedef.keys()))
+                required = [t for t in frame.types if t in frame.shapedef]
+                not_defined = [t for t in frame.types if t not in frame.shapedef]
                 for name in required:
                     _write('def {} "{}"'.format(name, frame.shapedef[name].pos_string))
                 for name in not_defined:

--- a/garnett/posfilewriter.py
+++ b/garnett/posfilewriter.py
@@ -115,7 +115,7 @@ class PosFileWriter(object):
 
             # Orientations must be provided for all particles
             # If the frame does not have orientations, identity quaternions are used
-            orientation = getattr(frame, 'orientation', np.array([[1, 0, 0, 0]] * len(frame.types)))
+            orientation = getattr(frame, 'orientation', np.array([[1, 0, 0, 0]] * frame.N))
 
             for typeid, pos, rot in zip(frame.typeid, frame.position, orientation):
                 name = frame.types[typeid]

--- a/garnett/shapes.py
+++ b/garnett/shapes.py
@@ -20,6 +20,7 @@ __all__ = [
     'ConvexPolyhedronUnionShape',
     'ConvexSpheropolyhedronShape',
     'GeneralPolyhedronShape',
+    'EllipsoidShape',
 ]
 
 logger = logging.getLogger(__name__)

--- a/garnett/shapes.py
+++ b/garnett/shapes.py
@@ -536,49 +536,49 @@ def _parse_type_shape(shape):
     if not shape:
         return FallbackShape('')
 
-    rounding_radius = shape.get('rounding_radius', 0)
-    shape_type = shape['type'].lower()
+    type_name = shape['type'].lower()
+    type_shape = None
 
-    shapedef = None
-
-    if shape_type in ('sphere', 'disk'):
+    if type_name in ('sphere', 'disk'):
         # disk support is for backwards compatibility with get_type_shapes()
         # from HOOMD-blue < 2.7
         diameter = shape.get('diameter', 2*shape.get('rounding_radius', 0.5))
         orientable = shape.get('orientable', False)
-        shapedef = SphereShape(diameter=diameter, orientable=orientable, color=None)
-    elif shape_type == 'ellipsoid':
-        shapedef = EllipsoidShape(a=shape['a'], b=shape['b'], c=shape['c'], color=None)
-    elif shape_type == 'polygon':
+        type_shape = SphereShape(diameter=diameter, orientable=orientable, color=None)
+    elif type_name == 'ellipsoid':
+        type_shape = EllipsoidShape(a=shape['a'], b=shape['b'], c=shape['c'], color=None)
+    elif type_name == 'polygon':
+        rounding_radius = shape.get('rounding_radius', 0)
         if rounding_radius == 0:
-            shapedef = PolygonShape(vertices=shape['vertices'], color=None)
+            type_shape = PolygonShape(vertices=shape['vertices'], color=None)
         else:
-            shapedef = SpheropolygonShape(vertices=shape['vertices'],
-                                          rounding_radius=rounding_radius,
-                                          color=None)
-    elif shape_type == 'convexpolyhedron':
+            type_shape = SpheropolygonShape(vertices=shape['vertices'],
+                                            rounding_radius=rounding_radius,
+                                            color=None)
+    elif type_name == 'convexpolyhedron':
+        rounding_radius = shape.get('rounding_radius', 0)
         if rounding_radius == 0:
-            shapedef = ConvexPolyhedronShape(vertices=shape['vertices'], color=None)
+            type_shape = ConvexPolyhedronShape(vertices=shape['vertices'], color=None)
         else:
-            shapedef = ConvexSpheropolyhedronShape(vertices=shape['vertices'],
-                                                   rounding_radius=rounding_radius,
-                                                   color=None)
-    elif shape_type == 'mesh':
-        shapedef = GeneralPolyhedronShape(vertices=shape['vertices'],
-                                          faces=shape['indices'],
-                                          facet_colors=shape['colors'],
-                                          color=None)
-    elif shape_type == 'polyhedron':
+            type_shape = ConvexSpheropolyhedronShape(vertices=shape['vertices'],
+                                                     rounding_radius=rounding_radius,
+                                                     color=None)
+    elif type_name == 'mesh':
+        type_shape = GeneralPolyhedronShape(vertices=shape['vertices'],
+                                            faces=shape['indices'],
+                                            facet_colors=shape['colors'],
+                                            color=None)
+    elif type_name == 'polyhedron':
         # polyhedron support is for backwards compatibility with
         # get_type_shapes() from HOOMD-blue < 2.7
-        shapedef = GeneralPolyhedronShape(vertices=shape['vertices'],
-                                          faces=shape['faces'],
-                                          facet_colors=shape['colors'],
-                                          color=None)
+        type_shape = GeneralPolyhedronShape(vertices=shape['vertices'],
+                                            faces=shape['faces'],
+                                            facet_colors=shape['colors'],
+                                            color=None)
 
-    if shapedef is None:
+    if type_shape is None:
         logger.warning("Failed to parse shape definition: shape {} not supported. "
-                       "Using fallback mode.".format(shape_type))
-        shapedef = FallbackShape(json.dumps(shape))
+                       "Using fallback mode.".format(type_name))
+        type_shape = FallbackShape(json.dumps(shape))
 
-    return shapedef
+    return type_shape

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -24,15 +24,18 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DTYPE = np.float32
 
+# Scalar properties for a frame
 FRAME_PROPERTIES = {
     'N': np.uint,
 }
 
+# Properties of length T (number of types)
 TYPE_PROPERTIES = {
     'types': str,
     'type_shapes': object,
 }
 
+# Properties of length N (number of particles)
 PARTICLE_PROPERTIES = {
     'typeid': np.uint,
     'position': DEFAULT_DTYPE,

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -1284,13 +1284,17 @@ def _regularize_box(position, velocity,
     return position, velocity, orientation, angmom, box
 
 
-def _generate_type_id_array(types, type_ids):
-    "Generate type_id array."
-    _type = sorted(set(t_ for t in types for t_ in t))
-    for i, t in enumerate(types):
-        for j, t_ in enumerate(t):
-            type_ids[i][j] = _type.index(t_)
-    return _type
+def _generate_types_typeid(type_strings):
+    """Generate types and typeid from list of type strings."""
+    types = []
+    typeid = []
+    for name in map(str, type_strings):
+        if name not in types:
+            types.append(name)
+        typeid.append(types.index(name))
+    types = np.asarray(types, dtype=str)
+    typeid = np.asarray(typeid, dtype=np.uint)
+    return types, typeid
 
 
 def _to_hoomd_snapshot(frame, snapshot=None):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -135,6 +135,8 @@ class FrameData(object):
         "Instance of :class:`~.Box`"
         self.types = None
         "T array of type names represented as strings."
+        self.type_shapes = None
+        "T array of shape instances."
         self.typeid = None
         "N array of type indices for N particles."
         self.position = None

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -962,10 +962,10 @@ class Trajectory(BaseTrajectory):
         return max((len(f) for f in self.frames))
 
     def load_arrays(self):
-        """Load positions, orientations and types into memory.
+        """Load all trajectory properties into memory.
 
-        After calling this function, positions, orientations
-        and types can be accessed as coherent NumPy arrays:
+        After calling this function, all properties can be accessed as coherent
+        NumPy arrays:
 
         .. code::
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -747,6 +747,12 @@ class Frame(object):
         self.frame_data.data_keys = value
 
     @property
+    @deprecation.deprecated(
+        deprecated_in="0.7.0",
+        removed_in="0.8.0",
+        current_version=__version__,
+        details=("This property is deprecated, use type_shapes instead. "
+                 "If setting shapedef, the entire dictionary must be set at once."))
     def shapedef(self):
         "An ordered dictionary of instances of :class:`~.shapes.Shape`."
         types = self.types

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -9,6 +9,7 @@ trajectories."""
 
 import logging
 import deprecation
+from collections import OrderedDict
 
 import numpy as np
 import rowan
@@ -23,21 +24,37 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DTYPE = np.float32
 
-PARTICLE_PROPERTIES = ['position',
-                       'orientation',
-                       'velocity',
-                       'mass',
-                       'charge',
-                       'diameter',
-                       'moment_inertia',
-                       'angmom',
-                       'image']
+FRAME_PROPERTIES = {
+    'N': np.uint,
+}
 
-FRAME_TRAJ_PROPS = PARTICLE_PROPERTIES + ['N', 'type', 'types', 'type_ids']
+TYPE_PROPERTIES = {
+    'types': str,
+    'type_shapes': object,
+}
+
+PARTICLE_PROPERTIES = {
+    'typeid': np.uint,
+    'position': DEFAULT_DTYPE,
+    'orientation': DEFAULT_DTYPE,
+    'velocity': DEFAULT_DTYPE,
+    'mass': DEFAULT_DTYPE,
+    'charge': DEFAULT_DTYPE,
+    'diameter': DEFAULT_DTYPE,
+    'moment_inertia': DEFAULT_DTYPE,
+    'angmom': DEFAULT_DTYPE,
+    'image': np.int_,
+}
+
+TRAJECTORY_PROPERTIES = {
+    **FRAME_PROPERTIES,
+    **TYPE_PROPERTIES,
+    **PARTICLE_PROPERTIES
+}
 
 
 class Box(object):
-    """A triclinical box class.
+    """A triclinic box class.
 
     You can access the box size and tilt factors via attributes:
 
@@ -114,7 +131,9 @@ class FrameData(object):
         self.box = None
         "Instance of :class:`~.Box`"
         self.types = None
-        "Nx1 array of types represented as strings."
+        "T array of type names represented as strings."
+        self.typeid = None
+        "N array of type indices for N particles."
         self.position = None
         "Nx3 array of coordinates for N particles in 3 dimensions."
         self.orientation = None
@@ -137,31 +156,30 @@ class FrameData(object):
         "A dictionary of lists for each attribute."
         self.data_keys = None
         "A list of strings, where each string represents one attribute."
-        self.shapedef = None
-        "A ordered dictionary of instances of :class:`~.shapes.ShapeDefinition`."
         self.view_rotation = None
         "A quaternion specifying a rotation that should be applied for visualization."
 
     def __len__(self):
-        return len(self.types)
+        return len(self.position)
 
     def __eq__(self, other):
         if len(self) != len(other):
             return False
         else:  # rigorous comparison required
             return self.box == other.box \
-                and self.types == other.types\
-                and np.array_equal(self.position, other.position)\
-                and np.array_equal(self.orientation, other.orientation)\
-                and np.array_equal(self.velocity, other.velocity)\
-                and np.array_equal(self.mass, other.mass)\
-                and np.array_equal(self.charge, other.charge)\
-                and np.array_equal(self.diameter, other.diameter)\
-                and np.array_equal(self.moment_inertia, other.moment_inertia)\
-                and np.array_equal(self.angmom, other.angmom)\
-                and np.array_equal(self.image, other.image)\
-                and self.data == other.data\
-                and self.shapedef == other.shapedef
+                and self.types == other.types \
+                and np.array_equal(self.typeid, other.typeid) \
+                and np.array_equal(self.position, other.position) \
+                and np.array_equal(self.orientation, other.orientation) \
+                and np.array_equal(self.velocity, other.velocity) \
+                and np.array_equal(self.mass, other.mass) \
+                and np.array_equal(self.charge, other.charge) \
+                and np.array_equal(self.diameter, other.diameter) \
+                and np.array_equal(self.moment_inertia, other.moment_inertia) \
+                and np.array_equal(self.angmom, other.angmom) \
+                and np.array_equal(self.image, other.image) \
+                and self.data == other.data \
+                and self.type_shapes == other.type_shapes
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -196,13 +214,15 @@ class FrameData(object):
 class _RawFrameData(object):
     """Class to capture unprocessed frame data during parsing.
 
-    All matrices are numpy arrays."""
+    All matrices are NumPy arrays."""
 
     def __init__(self):
         # 3x3 matrix (not required to be upper-triangular)
         self.box = None
         self.box_dimensions = 3
-        self.types = list()                         # Nx1
+        self.types = list()                         # T
+        self.type_shapes = list()                   # T
+        self.typeid = list()                        # N
         self.position = list()                      # Nx3
         self.orientation = list()                   # Nx4
         self.velocity = list()                      # Nx3
@@ -215,8 +235,6 @@ class _RawFrameData(object):
         # A dictionary of lists for each attribute
         self.data = None
         self.data_keys = None                       # A list of strings
-        # A ordered dictionary of instances of ShapeDefinition
-        self.shapedef = None
         # A view rotation (does not affect the actual trajectory)
         self.view_rotation = None
 
@@ -259,12 +277,14 @@ class Frame(object):
 
     def _raw_frame_to_frame(self, raw_frame, dtype=None):
         """Generate a frame object from a raw frame object."""
-        N = len(raw_frame.types)
+        N = len(raw_frame.position)
         ret = FrameData()
 
         mapping = dict()
-        for prop in PARTICLE_PROPERTIES:
-            mapping[prop] = np.asarray(getattr(raw_frame, prop), dtype=dtype)
+        for prop, dtype_ in PARTICLE_PROPERTIES.items():
+            if dtype_ == DEFAULT_DTYPE:
+                dtype_ = dtype
+            mapping[prop] = np.asarray(getattr(raw_frame, prop), dtype=dtype_)
             if len(mapping[prop]) == 0:
                 mapping[prop] = None
 
@@ -281,10 +301,11 @@ class Frame(object):
                                                          raw_frame.box,
                                                          dtype,
                                                          box_dimensions)
+        ret.types = raw_frame.types
+        ret.type_shapes = raw_frame.type_shapes
+        ret.typeid = raw_frame.typeid
         for prop in PARTICLE_PROPERTIES:
             setattr(ret, prop, mapping[prop])
-        ret.shapedef = raw_frame.shapedef
-        ret.types = raw_frame.types
         ret.data = raw_frame.data
         ret.data_keys = raw_frame.data_keys
         ret.view_rotation = raw_frame.view_rotation
@@ -332,8 +353,7 @@ class Frame(object):
 
     def __len__(self):
         "Return the number of particles in this frame."
-        self.load()
-        return len(self.frame_data)
+        return self.N
 
     def __eq__(self, other):
         self.load()
@@ -484,6 +504,12 @@ class Frame(object):
         return scene
 
     @property
+    def N(self):
+        "Number of particles."
+        self.load()
+        return len(self.frame_data)
+
+    @property
     def box(self):
         "Instance of :class:`~.Box`"
         self.load()
@@ -496,14 +522,36 @@ class Frame(object):
 
     @property
     def types(self):
-        "Nx1 array of types represented as strings."
+        "T array of type names represented as strings."
         self.load()
-        return self.frame_data.types
+        return self._raise_attributeerror('types')
 
     @types.setter
     def types(self, value):
         self.load()
         self.frame_data.types = value
+
+    @property
+    def type_shapes(self):
+        "T list of shape definitions."
+        self.load()
+        return self._raise_attributeerror('type_shapes')
+
+    @type_shapes.setter
+    def type_shapes(self, value):
+        self.load()
+        self.frame_data.type_shapes = value
+
+    @property
+    def typeid(self):
+        "N array of type indices for N particles."
+        self.load()
+        return self.frame_data.typeid
+
+    @typeid.setter
+    def typeid(self, value):
+        self.load()
+        self.frame_data.typeid = value
 
     @property
     def position(self):
@@ -695,13 +743,17 @@ class Frame(object):
     @property
     def shapedef(self):
         "An ordered dictionary of instances of :class:`~.shapes.Shape`."
-        self.load()
-        return self._raise_attributeerror('shapedef')
+        types = self.types
+        type_shapes = self.type_shapes
+        if len(types) != len(type_shapes):
+            raise AttributeError('Number of types and type_shapes is inconsistent.')
+        else:
+            return OrderedDict(zip(self.types, self.type_shapes))
 
     @shapedef.setter
     def shapedef(self, value):
-        self.load()
-        self.frame_data.shapedef = value
+        self.types = list(value.keys())
+        self.type_shapes = list(value.values())
 
     @property
     def view_rotation(self):
@@ -730,12 +782,10 @@ class BaseTrajectory(object):
     def __getitem__(self, index):
         if isinstance(index, slice):
             traj = type(self)(self.frames[index])
-            for x in ('_N', '_types', '_type', '_type_ids',
-                      '_position', '_orientation', '_velocity',
-                      '_mass', '_charge', '_diameter',
-                      '_moment_inertia', '_angmom', '_image'):
-                if getattr(self, x) is not None:
-                    setattr(traj, x, getattr(self, x)[index])
+            for prop in TRAJECTORY_PROPERTIES:
+                prop_key = '_' + prop
+                if getattr(self, prop_key) is not None:
+                    setattr(traj, prop_key, getattr(self, prop_key)[index])
             return traj
         else:
             return self.frames[index]
@@ -785,7 +835,7 @@ class Trajectory(BaseTrajectory):
 
     A trajectory is basically a sequence of :class:`~.Frame` instances.
 
-    Trajectory data can either be accessed as coherent numpy arrays:
+    Trajectory data can either be accessed as coherent NumPy arrays:
 
     .. code::
 
@@ -794,8 +844,7 @@ class Trajectory(BaseTrajectory):
         traj.N             # M
         traj.position      # MxNx3
         traj.orientation   # MxNx4
-        traj.types         # MxN
-        traj.type_ids      # MxN
+        traj.typeid        # MxN
 
     or by individual frames:
 
@@ -833,9 +882,9 @@ class Trajectory(BaseTrajectory):
             dtype = DEFAULT_DTYPE
         self._dtype = dtype
         self._N = None
-        self._type = None
         self._types = None
-        self._type_ids = None
+        self._type_shapes = None
+        self._typeid = None
         self._position = None
         self._orientation = None
         self._velocity = None
@@ -876,7 +925,7 @@ class Trajectory(BaseTrajectory):
         """Returns true if arrays are loaded into memory.
 
         See also: :meth:`~.load_arrays`"""
-        return any(getattr(self, '_' + key) is not None for key in FRAME_TRAJ_PROPS)
+        return any(getattr(self, '_' + key) is not None for key in TRAJECTORY_PROPERTIES)
 
     def _assert_loaded(self):
         "Raises a RuntimeError if trajectory is not loaded."
@@ -904,7 +953,7 @@ class Trajectory(BaseTrajectory):
         """Load positions, orientations and types into memory.
 
         After calling this function, positions, orientations
-        and types can be accessed as coherent numpy arrays:
+        and types can be accessed as coherent NumPy arrays:
 
         .. code::
 
@@ -912,8 +961,7 @@ class Trajectory(BaseTrajectory):
             traj.N             # M -- frame sizes
             traj.position      # MxNx3
             traj.orientation   # MxNx4
-            traj.types         # MxN
-            traj.type_ids      # MxN
+            traj.typeid        # MxN
 
         .. note::
 
@@ -935,73 +983,36 @@ class Trajectory(BaseTrajectory):
                 sub_traj.load_arrays()
                 sub_traj.position
         """
-        # Determine array shapes
-        _N = np.array([len(f) for f in self.frames], dtype=np.int_)
-        M = len(self)
-        N = _N.max()
+        # Set up dictionary of properties with a list of values for each frame.
+        props = {prop: [None] * len(self) for prop in TRAJECTORY_PROPERTIES}
 
-        # Types
-        types = [f.types for f in self.frames]
-        type_ids = np.zeros((M, N), dtype=np.uint32)
-        _type = _generate_type_id_array(types, type_ids)
-
-        props = dict(
-            position=[None] * M,
-            orientation=[None] * M,
-            velocity=[None] * M,
-            mass=[None] * M,
-            charge=[None] * M,
-            diameter=[None] * M,
-            moment_inertia=[None] * M,
-            angmom=[None] * M,
-            image=[None] * M,
-        )
-
+        # Copy attributes from frames into props.
         for i, frame in enumerate(self.frames):
-            # loop over desired properties
-            for prop in PARTICLE_PROPERTIES:
-                try:
-                    frame_prop = frame._raise_attributeerror(prop)
-                except AttributeError:
-                    frame_prop = None
-                if frame_prop is not None:
-                    props[prop][i] = frame_prop
+            for prop in TRAJECTORY_PROPERTIES:
+                props[prop][i] = getattr(frame, prop, None)
 
-        for prop in PARTICLE_PROPERTIES:
-            # This builds NumPy arrays for properties with
-            # no missing values (i.e. None).
+        # Build NumPy arrays for properties with no missing values (i.e. None).
+        for prop, dtype_ in TRAJECTORY_PROPERTIES.items():
             if any(p is None for p in props[prop]):
                 # If the list contains a None value, set property to None
-                # in order for AttributeError to be raised properly
+                # in order for AttributeError to be raised properly.
                 props[prop] = None
             else:
-                dtype_ = np.int32 if prop == 'image' else DEFAULT_DTYPE
                 try:
                     props[prop] = np.asarray(props[prop], dtype=dtype_)
                 except (TypeError, ValueError):
                     props[prop] = np.asarray(props[prop])
 
+        # Copy props data into trajectory's hidden attributes.
         try:
-            # Perform swap
-            self._N = _N
-            self._type = _type
-            self._types = types
-            self._type_ids = type_ids
-            self._position = props['position']
-            self._orientation = props['orientation']
-            self._velocity = props['velocity']
-            self._mass = props['mass']
-            self._charge = props['charge']
-            self._diameter = props['diameter']
-            self._moment_inertia = props['moment_inertia']
-            self._angmom = props['angmom']
-            self._image = props['image']
+            for prop in TRAJECTORY_PROPERTIES:
+                prop_key = '_' + prop
+                setattr(self, prop_key, props[prop])
         except Exception:
-            # Ensure consistent error state
-            self._N = self._type = self._types = self._type_ids = \
-                self._position = self._orientation = self._velocity = \
-                self._mass = self._charge = self._diameter = \
-                self._moment_inertia = self._angmom = self._image = None
+            # Ensure consistent error state by resetting all properties
+            for prop in TRAJECTORY_PROPERTIES:
+                prop_key = '_' + prop
+                setattr(self, prop_key, None)
             raise
 
     def set_dtype(self, value):
@@ -1022,7 +1033,7 @@ class Trajectory(BaseTrajectory):
 
     @property
     def N(self):
-        """Access the frame sizes as a numpy array.
+        """Access the frame sizes as a NumPy array.
 
         Mostly important when the trajectory has varying size.
 
@@ -1036,13 +1047,13 @@ class Trajectory(BaseTrajectory):
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
-        return np.asarray(self._N, dtype=np.int_)
+        return np.asarray(self._N, dtype=np.uint)
 
     @property
     def types(self):
-        """Access the particle types as a numpy array.
+        """List of type names ordered by type_id.
 
-        :returns: particles types as (MxN) array
+        :returns: particles type names as (MxT) array
         :rtype: :class:`numpy.ndarray` (dtype= :class:`numpy.str_` )
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
@@ -1051,28 +1062,8 @@ class Trajectory(BaseTrajectory):
         return np.asarray(self._types, dtype=np.str_)
 
     @property
-    def type(self):
-        """List of type names ordered by type_id.
-
-        Use the type list to map between type_ids and type names:
-
-        .. code::
-
-            type_name = traj.type[type_id]
-
-        See also: :attr:`~.Trajectory.type_ids`
-
-        :returns: particle types in order of type id.
-        :rtype: list
-        :raises RuntimeError: When accessed before
-            calling :meth:`~.load_arrays` or
-            :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
-        return self._type
-
-    @property
-    def type_ids(self):
-        """Access the particle type ids as a numpy array.
+    def typeid(self):
+        """Access the particle type ids as a NumPy array.
 
         See also: :attr:`~.Trajectory.type`
 
@@ -1082,11 +1073,11 @@ class Trajectory(BaseTrajectory):
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
-        return np.asarray(self._type_ids, dtype=np.int_)
+        return np.asarray(self._typeid, dtype=np.uint)
 
     @property
     def position(self):
-        """Access the particle positions as a numpy array.
+        """Access the particle positions as a NumPy array.
 
         :returns: particle positions as (Nx3) array
         :rtype: :class:`numpy.ndarray`
@@ -1109,7 +1100,7 @@ class Trajectory(BaseTrajectory):
 
     @property
     def orientation(self):
-        """Access the particle orientations as a numpy array.
+        """Access the particle orientations as a NumPy array.
 
         Orientations are stored as quaternions.
 
@@ -1132,7 +1123,7 @@ class Trajectory(BaseTrajectory):
 
     @property
     def velocity(self):
-        """Access the particle velocities as a numpy array.
+        """Access the particle velocities as a NumPy array.
 
         :returns: particle velocities as (Nx3) array
         :rtype: :class:`numpy.ndarray`
@@ -1153,7 +1144,7 @@ class Trajectory(BaseTrajectory):
 
     @property
     def mass(self):
-        """Access the particle mass as a numpy array.
+        """Access the particle mass as a NumPy array.
 
         :returns: particle mass as (N) element array
         :rtype: :class:`numpy.ndarray`
@@ -1165,7 +1156,7 @@ class Trajectory(BaseTrajectory):
 
     @property
     def charge(self):
-        """Access the particle charge as a numpy array.
+        """Access the particle charge as a NumPy array.
 
         :returns: particle charge as (N) element array
         :rtype: :class:`numpy.ndarray`
@@ -1177,7 +1168,7 @@ class Trajectory(BaseTrajectory):
 
     @property
     def diameter(self):
-        """Access the particle diameter as a numpy array.
+        """Access the particle diameter as a NumPy array.
 
         :returns: particle diameter as (N) element array
         :rtype: :class:`numpy.ndarray`
@@ -1190,7 +1181,7 @@ class Trajectory(BaseTrajectory):
     @property
     def moment_inertia(self):
         """Access the particle principal moment of inertia components as a
-        numpy array.
+        NumPy array.
 
         :returns: particle principal moment of inertia components as (Nx3)
                   element array
@@ -1203,7 +1194,7 @@ class Trajectory(BaseTrajectory):
 
     @property
     def angmom(self):
-        """Access the particle angular momenta as a numpy array.
+        """Access the particle angular momenta as a NumPy array.
 
         :returns: particle angular momenta quaternions as (Nx4) element array
         :rtype: :class:`numpy.ndarray`
@@ -1215,7 +1206,7 @@ class Trajectory(BaseTrajectory):
 
     @property
     def image(self):
-        """Access the particle periodic images as a numpy array.
+        """Access the particle periodic images as a NumPy array.
 
         :returns: particle periodic images as (Nx3) element array
         :rtype: :class:`numpy.ndarray`
@@ -1345,10 +1336,7 @@ def _from_hoomd_snapshot(frame, snapshot):
     Note that only the properties listed below will be copied.
     """
     frame.box.__dict__ = snapshot.box.__dict__
-    particle_types = list(set(snapshot.particles.types))
-    snap_types = [particle_types[i] for i in snapshot.particles.typeid]
-    frame.types = snap_types
-    for prop in PARTICLE_PROPERTIES:
+    for prop in {**TYPE_PROPERTIES, **PARTICLE_PROPERTIES}:
         setattr(frame, prop, getattr(snapshot.particles, prop))
     return frame
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -944,7 +944,7 @@ class Trajectory(BaseTrajectory):
         if not self.loaded():
             raise RuntimeError("Trajectory not loaded! Use load().")
 
-    def _assertarrays_loaded(self):
+    def _assert_arrays_loaded(self):
         "Raises a RuntimeError if trajectory arrays are not loaded."
         if not self.arrays_loaded():
             raise RuntimeError(
@@ -1058,7 +1058,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_N')
 
     @property
@@ -1070,7 +1070,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_types')
 
     @property
@@ -1084,7 +1084,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_typeid')
 
     @property
@@ -1096,7 +1096,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_position')
 
     @property
@@ -1121,7 +1121,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_orientation')
 
     @property
@@ -1142,7 +1142,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_velocity')
 
     @property
@@ -1163,7 +1163,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_mass')
 
     @property
@@ -1175,7 +1175,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_charge')
 
     @property
@@ -1187,7 +1187,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_diameter')
 
     @property
@@ -1201,7 +1201,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_moment_inertia')
 
     @property
@@ -1213,7 +1213,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_angmom')
 
     @property
@@ -1225,7 +1225,7 @@ class Trajectory(BaseTrajectory):
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
-        self._assertarrays_loaded()
+        self._assert_arrays_loaded()
         return self._check_nonempty_property('_image')
 
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -555,6 +555,7 @@ class Frame(object):
 
     @typeid.setter
     def typeid(self, value):
+        value = self._validate_input_array(value, dim=1, dtype=np.uint)
         self.load()
         self.frame_data.typeid = value
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -1059,7 +1059,7 @@ class Trajectory(BaseTrajectory):
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
-        return np.asarray(self._N, dtype=np.uint)
+        return self._check_nonempty_property('_N')
 
     @property
     def types(self):
@@ -1071,7 +1071,7 @@ class Trajectory(BaseTrajectory):
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
-        return np.asarray(self._types, dtype=np.str_)
+        return self._check_nonempty_property('_types')
 
     @property
     def typeid(self):
@@ -1085,7 +1085,7 @@ class Trajectory(BaseTrajectory):
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
-        return np.asarray(self._typeid, dtype=np.uint)
+        return self._check_nonempty_property('_typeid')
 
     @property
     def position(self):

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -135,6 +135,8 @@ class FrameData(object):
         "Instance of :class:`~.Box`"
         self.types = None
         "T array of type names represented as strings."
+        self.type_shapes = None
+        "T array of Shape objects."
         self.typeid = None
         "N array of type indices for N particles."
         self.position = None
@@ -269,8 +271,8 @@ class Frame(object):
         try:
             value = np.asarray(value, dtype=dtype)
         except ValueError:
-            raise ValueError("This property can only be set to numeric arrays.")
-        if not np.all(np.isfinite(value)):
+            raise ValueError("This property can only be set to values compatible with {}.".format(dtype))
+        if np.issubdtype(dtype, np.number) and not np.all(np.isfinite(value)):
             raise ValueError("Property being set must all be finite numbers.")
         elif len(value.shape) != dim:
             raise ValueError("Input array must be {}-dimensional.".format(dim))
@@ -531,6 +533,7 @@ class Frame(object):
 
     @types.setter
     def types(self, value):
+        value = self._validate_input_array(value, dim=1, dtype=TYPE_PROPERTIES['types'])
         self.load()
         self.frame_data.types = value
 
@@ -542,6 +545,7 @@ class Frame(object):
 
     @type_shapes.setter
     def type_shapes(self, value):
+        value = self._validate_input_array(value, dim=1, dtype=TYPE_PROPERTIES['type_shapes'])
         self.load()
         self.frame_data.type_shapes = value
 
@@ -553,6 +557,7 @@ class Frame(object):
 
     @typeid.setter
     def typeid(self, value):
+        value = self._validate_input_array(value, dim=1, dtype=PARTICLE_PROPERTIES['typeid'])
         self.load()
         self.frame_data.typeid = value
 
@@ -717,7 +722,7 @@ class Frame(object):
 
     @image.setter
     def image(self, value):
-        value = self._validate_input_array(value, dim=2, nelem=3, dtype=np.int32)
+        value = self._validate_input_array(value, dim=2, nelem=3, dtype=PARTICLE_PROPERTIES['image'])
         self.load()
         self.frame_data.image = value
 
@@ -744,6 +749,12 @@ class Frame(object):
         self.frame_data.data_keys = value
 
     @property
+    @deprecation.deprecated(deprecated_in="0.7.0",
+                            removed_in="0.8.0",
+                            current_version=__version__,
+                            details=("This property is deprecated, use type_shapes instead. "
+                                     "Until its removal, shapedef keys should not be individually "
+                                     "set, only the entire dictionary at once."))
     def shapedef(self):
         "An ordered dictionary of instances of :class:`~.shapes.Shape`."
         types = self.types
@@ -751,7 +762,7 @@ class Frame(object):
         if len(types) != len(type_shapes):
             raise AttributeError('Number of types and type_shapes is inconsistent.')
         else:
-            return OrderedDict(zip(self.types, self.type_shapes))
+            return OrderedDict(zip(types, type_shapes))
 
     @shapedef.setter
     def shapedef(self, value):
@@ -953,10 +964,10 @@ class Trajectory(BaseTrajectory):
         return max((len(f) for f in self.frames))
 
     def load_arrays(self):
-        """Load positions, orientations and types into memory.
+        """Load all available trajectory properties into memory.
 
-        After calling this function, positions, orientations
-        and types can be accessed as coherent NumPy arrays:
+        After calling this function, trajectory properties can be accessed as
+        coherent NumPy arrays:
 
         .. code::
 
@@ -1044,13 +1055,13 @@ class Trajectory(BaseTrajectory):
 
             pos_i = traj.position[i][0:traj.N[i]]
 
-        :returns: frame size as array with length M
+        :returns: frame sizes as array with length M
         :rtype: :class:`numpy.ndarray` (dtype= :class:`numpy.int_`)
         :raises RuntimeError: When accessed before
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
-        return np.asarray(self._N, dtype=np.uint)
+        return self._check_nonempty_property('_N')
 
     @property
     def types(self):
@@ -1062,7 +1073,7 @@ class Trajectory(BaseTrajectory):
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
-        return np.asarray(self._types, dtype=np.str_)
+        return self._check_nonempty_property('_types')
 
     @property
     def typeid(self):
@@ -1076,7 +1087,7 @@ class Trajectory(BaseTrajectory):
             calling :meth:`~.load_arrays` or
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
-        return np.asarray(self._typeid, dtype=np.uint)
+        return self._check_nonempty_property('_typeid')
 
     @property
     def position(self):

--- a/tests/files/shapes/generate_shape_data.py
+++ b/tests/files/shapes/generate_shape_data.py
@@ -98,8 +98,10 @@ shape_classes = [
     },
 ]
 
+
 def script_path(filename):
     return os.path.join(os.path.dirname(__file__), filename)
+
 
 if __name__ == '__main__':
     for shape_class in shape_classes:

--- a/tests/test_getarfilereader.py
+++ b/tests/test_getarfilereader.py
@@ -34,10 +34,9 @@ class BaseGetarFileReaderTest(unittest.TestCase):
         self.moment_inertia = np.random.rand(N, 3)
         self.angmom = np.random.rand(N, 4)
         self.image = np.random.randint(-1000, 1000, size=(N, 3), dtype=np.int32)
-        types = N // 2 * [0] + (N - N // 2) * [1]
-        type_names = ['A', 'B']
+        self.types = ['A', 'B']
+        self.typeid = N // 2 * [0] + (N - N // 2) * [1]
         self.box = np.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
-        self.types = [type_names[t] for t in types]
         if dim == 2:
             self.position[:, 2] = 0
             self.velocity[:, 2] = 0
@@ -53,8 +52,8 @@ class BaseGetarFileReaderTest(unittest.TestCase):
             traj.writePath('frames/0/angular_momentum_quat.f32.ind', self.angmom)
             traj.writePath('frames/0/box.f32.ind', self.box)
             traj.writePath('frames/0/image.i32.ind', self.image)
-            traj.writePath('type.u32.ind', types)
-            traj.writePath('type_names.json', json.dumps(type_names))
+            traj.writePath('type.u32.ind', self.typeid)
+            traj.writePath('type_names.json', json.dumps(self.types))
 
     def read_trajectory(self):
         reader = garnett.reader.GetarFileReader()
@@ -120,7 +119,7 @@ class NoTypesGetarFileReaderTest(BaseGetarFileReaderTest):
         self.angmom = np.random.rand(N, 4)
         self.image = np.random.randint(-1000, 1000, size=(N, 3), dtype=np.int32)
         self.box = np.array([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
-        self.types = N*['A']
+        self.types = ['A']
         if dim == 2:
             self.position[:, 2] = 0
             self.velocity[:, 2] = 0

--- a/tests/test_getarfilewriter.py
+++ b/tests/test_getarfilewriter.py
@@ -34,7 +34,7 @@ class BaseGetarFileWriterTest(unittest.TestCase):
         traj = garnett.reader.GSDHOOMDFileReader().read(gsdfile)
         traj.load_arrays()
         len_orig = len(traj)
-        readwrite_props = ['N', 'types', 'type_ids',
+        readwrite_props = ['N', 'types', 'typeid',
                            'position', 'orientation', 'velocity',
                            'mass', 'charge', 'diameter',
                            'moment_inertia', 'angmom', 'image']

--- a/tests/test_gsdhoomdfilewriter.py
+++ b/tests/test_gsdhoomdfilewriter.py
@@ -28,9 +28,9 @@ def get_filename(filename):
 
 
 class ColorlessShape(garnett.shapes.Shape):
-    """ShapeDefinition without colors, for comparing formats.
+    """Shape without colors, for comparing formats.
 
-    :param other: Another ShapeDefinition object.
+    :param other: Another Shape object.
     :type other: :py:class:`garnett.shapes.Shape`
     """
 
@@ -66,7 +66,7 @@ class BaseGSDHOOMDFileWriterTest(unittest.TestCase):
         traj = self.reader.read(gsdfile)
         traj.load_arrays()
         len_orig = len(traj)
-        readwrite_props = ['N', 'types', 'type_ids',
+        readwrite_props = ['N', 'types', 'typeid',
                            'position', 'orientation', 'velocity',
                            'mass', 'charge', 'diameter',
                            'moment_inertia', 'angmom', 'image']

--- a/tests/test_posfilereaderwriter.py
+++ b/tests/test_posfilereaderwriter.py
@@ -117,7 +117,8 @@ class PosFileReaderTest(BasePosFileReaderTest):
         box_expected = garnett.trajectory.Box(Lx=10, Ly=10, Lz=10)
         for frame in traj:
             N = len(frame)
-            self.assertEqual(frame.types, ['A'] * N)
+            self.assertEqual(frame.types, ['A'])
+            self.assertTrue(all(frame.typeid == [0] * N))
             self.assertEqual(frame.box, box_expected)
             self.assert_raise_attribute_error(frame)
 
@@ -130,7 +131,8 @@ class PosFileReaderTest(BasePosFileReaderTest):
         box_expected = garnett.trajectory.Box(Lx=10, Ly=10, Lz=10)
         for frame in traj:
             N = len(frame)
-            self.assertEqual(frame.types, ['A'] * N)
+            self.assertEqual(frame.types, ['A'])
+            self.assertTrue(all(frame.typeid == [0] * N))
             self.assertEqual(frame.box, box_expected)
             self.assert_raise_attribute_error(frame)
 
@@ -143,7 +145,8 @@ class PosFileReaderTest(BasePosFileReaderTest):
         box_expected = garnett.trajectory.Box(Lx=10, Ly=10, Lz=10)
         for frame in traj:
             N = len(frame)
-            self.assertEqual(frame.types, ['A'] * N)
+            self.assertEqual(frame.types, ['A'])
+            self.assertTrue(all(frame.typeid == [0] * N))
             self.assertEqual(frame.box, box_expected)
             self.assert_raise_attribute_error(frame)
 
@@ -156,7 +159,8 @@ class PosFileReaderTest(BasePosFileReaderTest):
         box_expected = garnett.trajectory.Box(Lx=10, Ly=10, Lz=10)
         for frame in traj:
             N = len(frame)
-            self.assertEqual(frame.types, ['A'] * N)
+            self.assertEqual(frame.types, ['A'])
+            self.assertTrue(all(frame.typeid == [0] * N))
             self.assertEqual(frame.box, box_expected)
             self.assert_raise_attribute_error(frame)
 
@@ -348,7 +352,7 @@ class PosFileWriterTest(BasePosFileWriterTest):
         traj = self.read_trajectory(sample)
         traj.load_arrays()
         for frame in traj:
-            frame.shapedef['A'] = ArrowShape()
+            frame.shapedef = {'A': ArrowShape()}
             frame.orientation.T[3] = 0
         dump = io.StringIO()
         self.write_trajectory(traj, dump)
@@ -368,7 +372,7 @@ class PosFileWriterTest(BasePosFileWriterTest):
         b = 0.25
         c = 0.125
         for frame in traj:
-            frame.shapedef['A'] = EllipsoidShape(a=a, b=b, c=c)
+            frame.shapedef = {'A': EllipsoidShape(a=a, b=b, c=c)}
         dump = io.StringIO()
         self.write_trajectory(traj, dump)
         dump.seek(0)

--- a/tests/test_posfilereaderwriter.py
+++ b/tests/test_posfilereaderwriter.py
@@ -180,8 +180,9 @@ class PosFileReaderTest(BasePosFileReaderTest):
             with garnett.read(posfile) as traj:
                 for frame in traj:
                     for name in frame.shapedef.keys():
-                        self.assertEqual(frame.shapedef[name], \
+                        self.assertEqual(frame.shapedef[name],
                                          DEFAULT_SHAPE_DEFINITION)
+
 
 @unittest.skipIf(not HPMC, 'requires HPMC')
 class HPMCPosFileReaderTest(BasePosFileReaderTest):

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -70,6 +70,7 @@ class ShapeTest(unittest.TestCase):
                 npt.assert_almost_equal(getattr(shape_A, key), value)
                 npt.assert_almost_equal(type_shape[key], value)
 
+
 @ddt
 class GSDShapeTest(ShapeTest):
     reader = garnett.reader.GSDHOOMDFileReader

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -360,6 +360,7 @@ class TrajectoryTest(unittest.TestCase):
             for frame in traj:
                 _access_deprected_props(frame, (N, 3), (N, 4), False)
 
+
 @unittest.skipIf(not HOOMD, 'requires hoomd-blue')
 class FrameSnapshotExport(TrajectoryTest):
 
@@ -380,14 +381,13 @@ class FrameSnapshotExport(TrajectoryTest):
         self.assertTrue((s0.particles.orientation ==
                          s1.particles.orientation).all())
 
-
     def test_to_hoomd_snapshot(self):
         traj = self.get_trajectory(garnett.samples.POS_HPMC)
         frame = traj[-1]
         snapshot = frame.to_hoomd_snapshot()
         for prop in PARTICLE_PROPERTIES:
             try:
-                self.assertTrue(np.array_equal(getattr(snapshot.particles, prop), \
+                self.assertTrue(np.array_equal(getattr(snapshot.particles, prop),
                                                getattr(frame, prop)))
             except AttributeError:
                 pass

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -124,19 +124,9 @@ class TrajectoryTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             traj.types
         traj.load_arrays()
-        self.assertTrue(np.issubdtype(traj.N.dtype, np.int_))
-        N = np.array([len(f) for f in traj], dtype=np.int_)
+        self.assertTrue(np.issubdtype(traj.N.dtype, np.uint))
+        N = np.array([len(f) for f in traj], dtype=np.uint)
         self.assertTrue((traj.N == N).all())
-
-    def test_type(self):
-        sample_file = self.get_sample_file()
-        traj = self.reader().read(sample_file)
-        with self.assertRaises(RuntimeError):
-            traj.types
-        traj.load_arrays()
-        self.assertTrue(isinstance(traj.type, list))
-        _type = sorted(set((t_ for f in traj for t_ in f.types)))
-        self.assertEqual(traj.type, _type)
 
     def test_types(self):
         sample_file = self.get_sample_file()
@@ -145,19 +135,18 @@ class TrajectoryTest(unittest.TestCase):
             traj.types
         traj.load_arrays()
         self.assertTrue(np.issubdtype(traj.types.dtype, np.str_))
-        self.assertEqual(traj.types.shape, (len(traj), len(traj[0])))
+        self.assertEqual(traj.types.shape, (len(traj), len(np.unique(traj[0].typeid))))
         self.assertTrue((traj.types[0] == traj[0].types).all())
 
-    def test_type_ids(self):
+    def test_typeid(self):
         sample_file = self.get_sample_file()
         traj = self.reader().read(sample_file)
         with self.assertRaises(RuntimeError):
             traj.types
         traj.load_arrays()
-        self.assertTrue(np.issubdtype(traj.type_ids.dtype, np.int_))
-        self.assertEqual(traj.type_ids.shape, (len(traj), len(traj[0])))
-        type_ids_0 = [traj.type.index(t) for t in traj.types[0]]
-        self.assertEqual(type_ids_0, traj.type_ids[0].tolist())
+        self.assertTrue(np.issubdtype(traj.typeid.dtype, np.uint))
+        self.assertEqual(traj.typeid.shape, (len(traj), len(traj[0])))
+        self.assertTrue((traj.typeid[0] == traj[0].typeid).all())
 
     def test_position(self):
         sample_file = self.get_sample_file()
@@ -327,7 +316,7 @@ class TrajectoryTest(unittest.TestCase):
         try:
             if len(traj.image.shape) > 1:
                 self.assertTrue(np.issubdtype(
-                    traj.image.dtype, np.int32))
+                    traj.image.dtype, np.int_), traj.image.dtype)
                 self.assertEqual(traj.image.shape,
                                  (len(traj), len(traj[0]), 3))
                 self.assertTrue((traj.image[0] == traj[0].image).all())


### PR DESCRIPTION
## Description
This PR rewrites the internals for `types` and `typeid` to match HOOMD's conventions.

## Motivation and Context
Resolves: #137.

## How Has This Been Tested?
The meanings of the type-related properties were changed, so I changed the expected behavior of the tests to match.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).