### PR TITLE
Enable trajectory property for box objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ frame.data             # Dictionary of lists for each attribute
 frame.data_key         # List of strings
 ```
 
-All matrices are `NumPy` arrays.
+All matrices are NumPy arrays.
 
 ## Example use with HOOMD-blue
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ sub_trajectory = traj[i:j]
 Access properties of trajectories:
 ```python
 traj.load_arrays()
+traj.box             # M
 traj.position        # MxNx3
 traj.orientation     # MxNx4
 traj.velocity        # MxNx3
@@ -87,7 +88,7 @@ traj.types           # MxT
 Access properties of individual frames:
 ```python
 frame = traj[i]
-frame.box              # 3x3 matrix (not required to be upper-triangular)
+frame.box              # garnett.trajectory.Box object
 frame.types            # T
 frame.typeid           # N
 frame.position         # Nx3
@@ -103,7 +104,7 @@ frame.data_key         # A list of strings
 frame.type_shapes      # T, Shape for each type
 ```
 
-All matrices are `numpy` arrays.
+All matrices are `NumPy` arrays.
 
 ## Example use with HOOMD-blue
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Added
 +++++
   - Added ability to read ``_space_group_symop_operation_xyz`` keys in CIF files.
   - Added ``to_hoomd_snapshot`` method to ``Frame`` objects. Replaces the deprecated ``make_snapshot`` and ``copyto_snapshot`` methods.
+  - Added ``box`` property to trajectory objects.
 
 Changed
 +++++++

--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -54,6 +54,11 @@ Sophie Youjung Lee, University of Michigan
 Luis Y. Rivera-Rivera, University of Michigan
 
     * Maintainer
+    * Various bugs and documentation fixes/updates
+    * Implemented error handling for unstored properties
+    * Improved dimension detection on GTAR and POS readers
+    * Enabled GSD v2.0.0 compatibility
+    * Added ``box`` to loadable trajectory attributes
 
 Kelly Wang, University of Michigan
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -82,6 +82,7 @@ Supported properties are listed below:
 .. code-block:: python
 
     traj.load_arrays()
+    traj.box             # M
     traj.N               # M
     traj.types           # MxT
     traj.position        # MxNx3

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -256,7 +256,7 @@ class DCDTrajectory(Trajectory):
         except Exception:
             # Ensure consistent error state
             self._box = self._N = self._type = self._types = \
-                self._type_ids = self._position = self._orientation =  None
+                self._type_ids = self._position = self._orientation = None
             raise
 
     def xyz(self, xyz=None):

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -128,9 +128,9 @@ class DCDFrame(Frame):
         self.offset = offset
         self.t_frame = t_frame
         self.default_type = default_type
+        self._box = None
         self._types = None
         self._typeid = None
-        self._box = None
         self._position = None
         self._orientation = None
         super(DCDFrame, self).__init__(dtype=dtype)
@@ -170,9 +170,9 @@ class DCDFrame(Frame):
         self._orientation = ort
 
     def _loaded(self):
-        return not (self._types is None or
+        return not (self._box is None or
+                    self._types is None or
                     self._typeid is None or
-                    self._box is None or
                     self._position is None or
                     self._orientation is None)
 
@@ -200,8 +200,8 @@ class DCDFrame(Frame):
         return raw_frame
 
     def unload(self):
-        self._types = None
         self._box = None
+        self._types = None
         self._position = None
         self._orientation = None
         super(DCDFrame, self).unload()
@@ -217,12 +217,12 @@ class DCDTrajectory(Trajectory):
         """Returns true if arrays are loaded into memory.
 
         See also: :meth:`~.load_arrays`"""
-        return not (self._N is None or
+        return not (self._box is None or
+                    self._N is None or
                     self._types is None or
                     self._typeid is None or
                     self._position is None or
-                    self._orientation is None or
-                    self._box is None)
+                    self._orientation is None)
 
     def load_arrays(self):
         # Determine array shapes
@@ -247,16 +247,16 @@ class DCDTrajectory(Trajectory):
 
         try:
             # Perform swap
+            self._box = box
             self._N = _N
             self._types = types
             self._typeid = typeid
             self._position = xyz.swapaxes(1, 2)
             self._orientation = ort
-            self._box = box
         except Exception:
             # Ensure consistent error state
-            self._N = self._type = self._types = self._type_ids = \
-                self._position = self._orientation = self._box = None
+            self._box = self._N = self._type = self._types = \
+                self._type_ids = self._position = self._orientation =  None
             raise
 
     def xyz(self, xyz=None):

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -243,7 +243,7 @@ class DCDTrajectory(Trajectory):
         typeid = np.asarray([f._typeid for f in self.frames],
                             dtype=PARTICLE_PROPERTIES['typeid'])
         box = np.asarray([f._box for f in self.frames],
-                         dtype=FRAME_PROPERTIES["box"])
+                         dtype=FRAME_PROPERTIES['box'])
 
         try:
             # Perform swap

--- a/garnett/dcdfilereader.py
+++ b/garnett/dcdfilereader.py
@@ -242,7 +242,8 @@ class DCDTrajectory(Trajectory):
                            dtype=TYPE_PROPERTIES['types'])
         typeid = np.asarray([f._typeid for f in self.frames],
                             dtype=PARTICLE_PROPERTIES['typeid'])
-        box = np.asarray([f._box for f in self.frames])
+        box = np.asarray([f._box for f in self.frames],
+                         dtype=FRAME_PROPERTIES["box"])
 
         try:
             # Perform swap

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -24,10 +24,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DTYPE = np.float32
 
-# Scalar/unique properties for a frame
+# Scalar/per-frame properties
 FRAME_PROPERTIES = {
     'N': np.uint,
-    'box', object
+    'box': object,
 }
 
 # Properties of length T (number of types)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -24,9 +24,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DTYPE = np.float32
 
-# Scalar properties for a frame
+# Scalar/unique properties for a frame
 FRAME_PROPERTIES = {
     'N': np.uint,
+    'box', object
 }
 
 # Properties of length T (number of types)
@@ -897,6 +898,7 @@ class Trajectory(BaseTrajectory):
         self._moment_inertia = None
         self._angmom = None
         self._image = None
+        self._box = None
 
     def __iter__(self):
         return iter(ImmutableTrajectory(self.frames))
@@ -1218,6 +1220,18 @@ class Trajectory(BaseTrajectory):
             :meth:`~.Trajectory.load`."""
         self._assertarrays_loaded()
         return self._check_nonempty_property('_image')
+
+    @property
+    def box(self):
+        """Access the frame boxes as a NumPy array.
+
+        :returns: frame boxes as an (M) element array
+        :rtype: :class:`numpy.ndarray` (dtype= :class:`~.Box`)
+        :raises RuntimeError: When accessed before
+            calling :meth:`~.load_arrays` or
+            :meth:`~.Trajectory.load`."""
+        self._assertarrays_loaded()
+        return self._check_nonempty_property('_box')
 
 
 def _regularize_box(position, velocity,

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -26,8 +26,8 @@ DEFAULT_DTYPE = np.float32
 
 # Scalar/per-frame properties
 FRAME_PROPERTIES = {
-    'N': np.uint,
     'box': object,
+    'N': np.uint,
 }
 
 # Properties of length T (number of types)

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -896,6 +896,7 @@ class Trajectory(BaseTrajectory):
         if dtype is None:
             dtype = DEFAULT_DTYPE
         self._dtype = dtype
+        self._box = None
         self._N = None
         self._types = None
         self._type_shapes = None
@@ -909,7 +910,6 @@ class Trajectory(BaseTrajectory):
         self._moment_inertia = None
         self._angmom = None
         self._image = None
-        self._box = None
 
     def __iter__(self):
         return iter(ImmutableTrajectory(self.frames))
@@ -1046,6 +1046,18 @@ class Trajectory(BaseTrajectory):
                 x = x.astype(value)
         for frame in self.frames:
             frame.dtype = value
+
+    @property
+    def box(self):
+        """Access the frame boxes as a NumPy array.
+
+        :returns: frame boxes as an (M) element array
+        :rtype: :class:`numpy.ndarray` (dtype= :class:`numpy.object_`)
+        :raises RuntimeError: When accessed before
+            calling :meth:`~.load_arrays` or
+            :meth:`~.Trajectory.load`."""
+        self._assert_arrays_loaded()
+        return self._check_nonempty_property('_box')
 
     @property
     def N(self):
@@ -1231,18 +1243,6 @@ class Trajectory(BaseTrajectory):
             :meth:`~.Trajectory.load`."""
         self._assert_arrays_loaded()
         return self._check_nonempty_property('_image')
-
-    @property
-    def box(self):
-        """Access the frame boxes as a NumPy array.
-
-        :returns: frame boxes as an (M) element array
-        :rtype: :class:`numpy.ndarray` (dtype= :class:`~.Box`)
-        :raises RuntimeError: When accessed before
-            calling :meth:`~.load_arrays` or
-            :meth:`~.Trajectory.load`."""
-        self._assert_arrays_loaded()
-        return self._check_nonempty_property('_box')
 
 
 def _regularize_box(position, velocity,

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -118,6 +118,18 @@ class TrajectoryTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             frame0.dtype = np.float64
 
+    def test_box(self):
+        sample_file = self.get_sample_file()
+        traj = self.reader().read(sample_file)
+        with self.assertRaises(RuntimeError):
+            traj.box
+        traj.load_arrays()
+        self.assertTrue(len(traj.box.shape) == 1)
+        self.assertTrue(np.issubdtype(traj.box.dtype, np.object_))
+        M = len(traj)
+        self.assertEqual(traj.box.shape, (M,))
+        self.assertTrue(np.all(traj.box[i] == traj[i].box for i in range(M)))
+
     def test_N(self):
         sample_file = self.get_sample_file()
         traj = self.reader().read(sample_file)
@@ -324,18 +336,6 @@ class TrajectoryTest(unittest.TestCase):
                 traj[0].image = 'hello'
         except AttributeError:
             pass
-
-    def test_box(self):
-        sample_file = self.get_sample_file()
-        traj = self.reader().read(sample_file)
-        with self.assertRaises(RuntimeError):
-            traj.box
-        traj.load_arrays()
-        self.assertTrue(len(traj.box.shape) == 1)
-        self.assertTrue(np.issubdtype(traj.box.dtype, np.object_))
-        M = len(traj)
-        self.assertEqual(traj.box.shape, (M,))
-        self.assertTrue(np.all(traj.box[i] == traj[i].box for i in range(M)))
 
     def test_deprecated(self):
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -325,6 +325,19 @@ class TrajectoryTest(unittest.TestCase):
         except AttributeError:
             pass
 
+    def test_box(self):
+        sample_file = self.get_sample_file()
+        traj = self.reader().read(sample_file)
+        with self.assertRaises(RuntimeError):
+            traj.box
+        traj.load_arrays()
+        print(traj.box)
+        self.assertTrue(len(traj.box.shape) == 1)
+        self.assertTrue(np.issubdtype(traj.box.dtype, object))
+        M = len(traj)
+        self.assertEqual(traj.box.shape, (M,))
+        self.assertTrue(np.all(traj.box[i] == traj[i].box for i in range(M)))
+
     def test_deprecated(self):
 
         def _access_deprected_props(obj, pos_shape, ort_shape, is_traj):

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -331,9 +331,8 @@ class TrajectoryTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             traj.box
         traj.load_arrays()
-        print(traj.box)
         self.assertTrue(len(traj.box.shape) == 1)
-        self.assertTrue(np.issubdtype(traj.box.dtype, object))
+        self.assertTrue(np.issubdtype(traj.box.dtype, np.object_))
         M = len(traj)
         self.assertEqual(traj.box.shape, (M,))
         self.assertTrue(np.all(traj.box[i] == traj[i].box for i in range(M)))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Thi PR enables accessing the frames' boxes from the trajectory object after loading arrays. 

It is based off of #137 so I'm opening as a draft until #137 is merged and potential merge conflicts are resolved.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #108 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
I added a test to ensure that the behavior works as expected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
