### PR TITLE
Improve CIF _atom_site_label type handling

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Added
 +++++
   - Added ability to read ``_space_group_symop_operation_xyz`` keys in CIF files.
   - Added ``to_hoomd_snapshot`` method to ``Frame`` objects. Replaces the deprecated ``make_snapshot`` and ``copyto_snapshot`` methods.
+  - The CIF reader supports a broader range of ``_atom_site_label`` values that match `component 0 as specified here <https://www.iucr.org/__data/iucr/cif/standard/cifstd15.html>`_.
 
 Changed
 +++++++

--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -45,6 +45,7 @@ Bradley Dice, University of Michigan
     * Support for additional frame properties
     * Improved support for parsing and writing particle shapes
     * Refactored ``types``, ``typeid``, ``type_shapes`` to match HOOMD conventions
+    * Expanded support for CIF ``_atom_site_label`` types.
 
 Sophie Youjung Lee, University of Michigan
 

--- a/garnett/ciffilereader.py
+++ b/garnett/ciffilereader.py
@@ -15,10 +15,11 @@ Authors: Matthew Spellings
 import logging
 import re
 import warnings
+from collections import OrderedDict
 
 import numpy as np
 
-from .trajectory import _RawFrameData, Frame, Trajectory, _generate_types_typeid
+from .trajectory import _RawFrameData, Frame, Trajectory
 
 # CifFile is from the pycifrw package
 from CifFile import CifFile
@@ -29,18 +30,32 @@ logger = logging.getLogger(__name__)
 
 CIFFILE_FLOAT_DIGITS = 11
 
-
 # invalid characters for symmetry expressions
 REMOVE_NONNUM_REGEXP = re.compile(r'[^+\-*/0-9\.,\(\)xyz]+')
 
 # (an integer or floating point number)/(an integer or floating point number)
 PARSE_DIVISION_REGEXP = re.compile(r'(?P<num>\d+(\.(\d+)?)?)\s*/\s*(?P<denom>\d+(\.(\d+)?)?)')
 
+# This regex matches _atom_site_label component 0 (but not component 1) of the
+# definition here:
+# https://www.iucr.org/__data/iucr/cif/standard/cifstd15.html
+_ATOM_SITE_LABEL_COMPONENT_0 = re.compile(r'^(([^ _0-9])|([0-9]*[\+\-]))*')
+
 
 def _parse_division(match):
     """Helper function to substitute ratios in cif files, like '1/4', into
     fractions, like '0.25'."""
     return str(float(match.group('num'))/float(match.group('denom')))
+
+
+def _parse_atom_site_label_to_type_name(label):
+    """Matches _atom_site_label component 0.
+
+    This regex matches component 0 (but not component 1) of the definition here:
+    https://www.iucr.org/__data/iucr/cif/standard/cifstd15.html
+    """
+    m = re.search(_ATOM_SITE_LABEL_COMPONENT_0, label)
+    return m.group()
 
 
 class _RawCifFrameData(_RawFrameData):
@@ -135,7 +150,7 @@ class CifFileFrame(Frame):
         if '_atom_site_type_symbol' in self.parsed:
             site_types = list(self.parsed['_atom_site_type_symbol'])
         elif '_atom_site_label' in self.parsed:
-            site_types = [re.search('([a-zA-Z]+)', label)
+            site_types = [_parse_atom_site_label_to_type_name(label)
                           for label in self.parsed['_atom_site_label']]
         else:
             site_types = len(fractions)*[self.default_type]
@@ -193,13 +208,17 @@ class CifFileFrame(Frame):
             unique_points = np.array(unique_points, dtype=np.float32)
 
             if bad_types:
+                site_types = [self.default_type]
                 type_strings = [self.default_type] * len(unique_points)
         else:
             unique_points = fractions
             type_strings = site_types
 
-        # Convert type strings to types, typeid
-        types, typeid = _generate_types_typeid(type_strings)
+        # Remove duplicate site_types while preserving their order
+        site_types = list(OrderedDict.fromkeys(site_types))
+
+        # Convert type strings to typeid
+        typeid = [site_types.index(t) for t in type_strings]
 
         # Save the exact points
         cif_coordinates = unique_points.copy()
@@ -213,7 +232,7 @@ class CifFileFrame(Frame):
 
         raw_frame = _RawFrameData()
         raw_frame.box = box_matrix
-        raw_frame.types = types
+        raw_frame.types = site_types
         raw_frame.typeid = typeid
         raw_frame.position = coordinates
         raw_frame.cif_coordinates = cif_coordinates

--- a/garnett/ciffilereader.py
+++ b/garnett/ciffilereader.py
@@ -39,7 +39,7 @@ PARSE_DIVISION_REGEXP = re.compile(r'(?P<num>\d+(\.(\d+)?)?)\s*/\s*(?P<denom>\d+
 # This regex matches _atom_site_label component 0 (but not component 1) of the
 # definition here:
 # https://www.iucr.org/__data/iucr/cif/standard/cifstd15.html
-_ATOM_SITE_LABEL_COMPONENT_0 = re.compile(r'^(([^ _0-9])|([0-9]*[\+\-]))*')
+_ATOM_SITE_LABEL_COMPONENT_0 = re.compile(r'^(([^\s_0-9])|([0-9]*[\+\-]))*')
 
 
 def _parse_division(match):

--- a/garnett/ciffilereader.py
+++ b/garnett/ciffilereader.py
@@ -88,7 +88,7 @@ class CifFileFrame(Frame):
         idx = s.rfind('(')
         return self._num(s[:idx]) if idx >= 0 else self._num(s)
 
-    def _parseBox(self, parsed):
+    def _parse_box(self, parsed):
         (a, b, c) = [self._safer_float(parsed['_cell_length_{}'.format(name)])
                      for name in ['a', 'b', 'c']]
         (alpha, beta, gamma) = [self._safer_float(parsed['_cell_angle_{}'.format(name)])
@@ -141,7 +141,7 @@ class CifFileFrame(Frame):
 
     def read(self):
         "Read the frame data from the stream."
-        box_matrix = self._parseBox(self.parsed)
+        box_matrix = self._parse_box(self.parsed)
 
         fractions = np.array([(self._safer_float(x), self._safer_float(y), self._safer_float(z))
                               for (x, y, z) in zip(

--- a/garnett/ciffilereader.py
+++ b/garnett/ciffilereader.py
@@ -218,7 +218,8 @@ class CifFileFrame(Frame):
         site_types = list(OrderedDict.fromkeys(site_types))
 
         # Convert type strings to typeid
-        typeid = [site_types.index(t) for t in type_strings]
+        site_types_lookup = {key: index for index, key in enumerate(site_types)}
+        typeid = [site_types_lookup[t] for t in type_strings]
 
         # Save the exact points
         cif_coordinates = unique_points.copy()

--- a/tests/test_ciffilereaderwriter.py
+++ b/tests/test_ciffilereaderwriter.py
@@ -20,6 +20,31 @@ logger = logging.getLogger(__name__)
 HP2_PATH = os.path.join(os.path.dirname(__file__), 'files', 'hP2-Mg.cif')
 
 
+class CifAtomSiteLabelParserTest(unittest.TestCase):
+
+    def test_parse_labels(self):
+        # Test parsing _atom_site_label.
+        # These examples are taken from:
+        # https://www.iucr.org/__data/iucr/cif/standard/cifstd15.html
+        parser = garnett.ciffilereader._parse_atom_site_label_to_type_name
+        assert parser('Cu') == 'Cu'
+        assert parser('Cu2+') == 'Cu2+'
+        assert parser('dummy') == 'dummy'
+        assert parser('Fe3+Ni2+') == 'Fe3+Ni2+'
+        assert parser('S-') == 'S-'
+        assert parser('H+') == 'H+'
+        assert parser('H*') == 'H*'
+        assert parser('H(SDS)') == 'H(SDS)'
+        assert parser('C1') == 'C'
+        assert parser('C103g28') == 'C'
+        assert parser('Fe3+17b') == 'Fe3+'
+        assert parser('H*251') == 'H*'
+        assert parser('boron2a') == 'boron'
+        assert parser('Ni22+') == 'Ni22+'
+        assert parser('Ni2+2') == 'Ni2+'
+        assert parser('Fe2+Ni2+2') == 'Fe2+Ni2+'
+
+
 @unittest.skipIf(not PYCIFRW,
                  'CifFileReader tests require the PyCifRW package.')
 class BaseCifFileReaderTest(unittest.TestCase):


### PR DESCRIPTION
## Description
Previously, garnett's CIF reader only caught certain valid `_atom_site_label` values. Simple ones like `H` or `C` were fine, but ions like `Fe3+` were just returning `Fe`. I have updated this behavior to adhere to any valid "component 0" as specified here: https://www.iucr.org/__data/iucr/cif/standard/cifstd15.html

Also, in some cases, parsed types were being returned as `re.match` objects instead of strings. This code now always returns strings.

I note that `_atom_site_label` values like `H1`, `H2`, ... that combine a "component 0" of `H` and a "component 1" of `1` (an atom number code) are always split, and their types are only the component 0. This matches the previous behavior of the code.

## Motivation

This was a behavior that caused difficulty reading some CIF files that I came across with @justinGilmer.

## How Has This Been Tested?
I added new tests for the parsing behavior.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
