### PR TITLE
Fix type subsetting in to_plato_scene.

### DIFF
--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -422,8 +422,8 @@ class Frame(object):
         prims.append(backend.Box.from_box(box, color=(0, 0, 0, 1)))
 
         # Create a shape primitive for each shape definition
-        for type_name, type_shape in self.shapedef.items():
-            subset = np.where(np.asarray(self.types) == type_name)[0]
+        for typeid, type_shape in enumerate(self.type_shapes):
+            subset = np.where(np.asarray(self.typeid) == typeid)[0]
             N_prim = len(subset)
             dimensions = self.box.dimensions
 

--- a/garnett/trajectory.py
+++ b/garnett/trajectory.py
@@ -421,7 +421,7 @@ class Frame(object):
             box.Lz = 0
         prims.append(backend.Box.from_box(box, color=(0, 0, 0, 1)))
 
-        # Create a shape primitive for each shape definition
+        # Create a shape primitive for each type
         for typeid, type_shape in enumerate(self.type_shapes):
             subset = np.where(np.asarray(self.typeid) == typeid)[0]
             N_prim = len(subset)


### PR DESCRIPTION
## Description
Fixes a bug in the behavior of `to_plato_scene` resulting from #137. I don't know how I would easily test this behavior -- it doesn't throw an error, it just picks the wrong subset. This led to only one particle showing, but that behavior may also depend on the plato version (its support for "unfolding" arrays has improved).

## Motivation and Context
Caught this bug while using `master`.

## How Has This Been Tested?
Behavior is fixed.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
