### PR TITLE
Skip writing attributes that aren't present in frames in GetarFileWriter

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 
 The **garnett** package follows `semantic versioning <https://semver.org/>`_.
 
+Unreleased Changes
+==================
+
+Added
++++++
+- Added support to `GetarFileWriter` for writing trajectories containing frames with some missing per-particle quantities.
+
+
 Version 0.7
 ===========
 

--- a/garnett/getarfilewriter.py
+++ b/garnett/getarfilewriter.py
@@ -73,8 +73,12 @@ class GetarFileWriter(object):
             # Particle properties
             for prop, recname in type(self).property_record_map.items():
                 rec = self.makeRecord(recname, index=index)
-                contents = getattr(frame, prop)
-                bulkwriter.writeRecord(rec=rec, contents=contents)
+                try:
+                    contents = getattr(frame, prop)
+                    bulkwriter.writeRecord(rec=rec, contents=contents)
+                except AttributeError:
+                    # skip attributes that aren't present
+                    pass
 
         # Box and dimensions
         box_rec = self.makeRecord('box.f32.uni', index=index)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This PR makes the getar file writer not crash when a frame is given that doesn't expose all of the per-particle quantities it expects to write.

## Motivation and Context
This might come up when trying to write a from-scratch trajectory frame that doesn't include the full set of quantities listed in the writer or when trying to write a garnett-native frame from a format that doesn't support them, for example:

```
import garnett

with garnett.read('cI16.cif') as in_file, open('/tmp/test.zip', 'w') as out_file:
    garnett.write(in_file, out_file)
```

```
Traceback (most recent call last):
  File "/tmp/test.py", line 4, in <module>
    garnett.write(in_file, out_file)
  File "/home/matthew/dev/garnett/garnett/util.py", line 145, in write
    file_writer.write(traj, write_file)
  File "/home/matthew/dev/garnett/garnett/getarfilewriter.py", line 123, in write
    self.writeFrame(t_writer, frame, index)
  File "/home/matthew/dev/garnett/garnett/getarfilewriter.py", line 76, in writeFrame
    contents = getattr(frame, prop)
  File "/home/matthew/dev/garnett/garnett/trajectory.py", line 641, in orientation
    return self._raise_attributeerror('orientation')
  File "/home/matthew/dev/garnett/garnett/trajectory.py", line 245, in _raise_attributeerror
    raise AttributeError('{} not available for this frame'.format(attr))
AttributeError: orientation not available for this frame
```

In my opinion it would be nice to fix this properly in a more general way (i.e. knowing, for each trajectory, which quantities are actually present at what frames and using some default schema when necessary), but this is a band-aid fix that works for now.

## How Has This Been Tested?
I added a quick test to the unit tests that writes a frame created with a namedtuple.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
