### PR TITLE
Fix frame ordering in GTAR-format files

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,10 @@ The **garnett** package follows `semantic versioning <https://semver.org/>`_.
 Unreleased Changes
 ==================
 
+Fixed
++++++
+- Fixed frame ordering for some trajectories read by `GetarFileReader`. Previously frames were ordered pseudo-arbitrarily depending on a bisection using lexicographic ordering of strings, rather than the key order specified by the gtar library.
+
 Added
 +++++
 - Added support to `GetarFileWriter` for writing trajectories containing frames with some missing per-particle quantities.

--- a/garnett/getarfilereader.py
+++ b/garnett/getarfilereader.py
@@ -32,9 +32,14 @@ def _find_le(a, x):
     raise ValueError
 
 
+def _gtar_index_key(index):
+    """Key by which to order GTAR frame indices"""
+    return (len(index), index)
+
+
 @functools.lru_cache(maxsize=64)
 def _get_record_frames(trajectory, record):
-    return trajectory.queryFrames(record)
+    return list(map(_gtar_index_key, trajectory.queryFrames(record)))
 
 
 class GetarFrame(Frame):
@@ -51,7 +56,7 @@ class GetarFrame(Frame):
         super(GetarFrame, self).__init__()
         self._trajectory = trajectory
         self._records = records
-        self._frame = frame
+        self._frame = _gtar_index_key(frame)
         self._default_type = default_type
         self._default_box = default_box
 
@@ -61,7 +66,7 @@ class GetarFrame(Frame):
     def _get_record_frame(self, name):
         record = self._records[name]
         frames = _get_record_frames(self._trajectory, record)
-        return _find_le(frames, self._frame)
+        return _find_le(frames, self._frame)[1]
 
     def _get_record_value(self, name):
         record = self._records[name]

--- a/tests/test_getarfilereader.py
+++ b/tests/test_getarfilereader.py
@@ -148,7 +148,7 @@ class GetarTrajectoryFrameTest(unittest.TestCase):
         self.getar_file_fn = os.path.join(self.tmp_dir.name, 'sample.tar')
 
         with gtar.GTAR(self.getar_file_fn, 'w') as traj:
-            for frame in range(6):
+            for frame in range(0, 18, 3):
                 traj.writePath('frames/{}/position.f32.ind'.format(frame),
                                [(0, 0, 0)])
                 if frame % 2:
@@ -163,7 +163,7 @@ class GetarTrajectoryFrameTest(unittest.TestCase):
     def test_ragged_frames(self):
         # first frame uses the default box value and a new value is
         # written on frame 1, 3, ...
-        target_lxs = [1, 2, 2, 4, 4, 6]
+        target_lxs = [1, 4, 4, 10, 10, 16]
         lxs = [frame.box.Lx for frame in self.trajectory]
         np.testing.assert_allclose(target_lxs, lxs)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->


This PR augments the list of returned frames to sort properly as a
tuple rather than specifying a key to the bisect function, which is
not supported until python 3.10.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Frames are read from getar files using a bisection sort. The GTAR
library returns frame indices (which are strings) sorted by
(len(index), index) to support the common use case of integer
frame indices. The bisection search was using the lexicographic
ordering of strings, which caused frames to be ordered incorrectly
depending on which set of frame indices was used.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
I loaded test trajectories to make sure that frames were in proper order.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
