### PR TITLE
Cif scaling

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,10 +10,16 @@ Unreleased Changes
 Fixed
 +++++
 - Fixed frame ordering for some trajectories read by `GetarFileReader`. Previously frames were ordered pseudo-arbitrarily depending on a bisection using lexicographic ordering of strings, rather than the key order specified by the gtar library.
+- Improved speed of `CifFileReader`.
 
 Added
 +++++
 - Added support to `GetarFileWriter` for writing trajectories containing frames with some missing per-particle quantities.
+
+Changed
++++++++
+
+- `CifFileReader` tolerance is now expressed in terms of real, rather than fractional, coordinates.
 
 
 Version 0.7


### PR DESCRIPTION


## Description
Previously, the duplicate-checking process for replicated coordinates (after applying symmetry operations) was O(N^2) for the sake of simplicity. This patch uses the sorting capability of `np.unique()` for O(N logN) behavior instead.

Simultaneously, the tolerance value for finding duplicated coordinates is now applied to the real-space coordinates, instead of fractional coordinates, to provide a more natural criterion for elongated boxes.

<!-- Provide a general summary of your changes in the Title above. --><!-- Describe your changes in detail. -->

## Motivation and Context
Drastically improves the efficiency of the cif file reader, especially for large unit cell sizes.

## How Has This Been Tested?
I double checked that the unit tests run with no issues and also tested integration with workflows of my own.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

There is a minor change in semantics: the tolerance specified in the reader now applied to real-space coordinates, rather than fractional-space. None of my code ever adjusted this tolerance, but real space seems like a more meaningful set of units to work in anyway.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/garnett/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/garnett/blob/master/doc/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/garnett/blob/master/changelog.rst).
